### PR TITLE
Adding omero-test-infra CI

### DIFF
--- a/.github/omero_test_infra.yaml
+++ b/.github/omero_test_infra.yaml
@@ -1,0 +1,34 @@
+# Install and test and OMERO plugin e.g. a Web app, a CLI plugin or a library
+#
+# This workflow will install omero-test-infra, start an OMERO environment
+# including database, server and web deployment, configure the OMERO plugin
+# and run integration tests.
+#
+# 1. Set up the stage variable depending on the plugin. Supported stages
+# are: app, cli, scripts, lib, srv
+#
+# 2. Adjust the cron schedule as necessary
+
+name: OMERO
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  test:
+    name: Run integration tests against OMERO
+    runs-on: ubuntu-latest
+    env:
+      STAGE: app
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout omero-test-infra
+        uses: actions/checkout@master
+        with:
+          repository: ome/omero-test-infra
+          path: .omero
+          ref: ${{ secrets.OMERO_TEST_INFRA_REF }}
+      - name: Build and run OMERO tests
+        run: .omero/docker $STAGE


### PR DESCRIPTION
Introduces omero-test-infra CI as per example in omero-test-infra's README.

@joshmoore/Carsten (not sure I know your handle here) please let me know if this is the right way to start.