### PR TITLE
Solves #33 public

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ To deploy your own OMERO-VKG, follow these steps:
 ### Generate site configuration directory
 In the top level directory, run the command
 ```console
-bash deploy.sh PREFIX URI
+bash deploy.sh PREFIX URI USERIDFILTER
 ```
 Replace `PREFIX` AND `URI` with the prefix name and URL for your OMERO instance, respectively. E.g. for the (hypothetical ) Institute of Bioimaging, running 
 OMERO at `https://ome.iob.net`, a sensible choice could be `bash deploy.sh iob https://ome.iob.net/`.
-This would create a new deployment directory named *iob\/* (in the example above),
+`USERIDFILTER` is a filter condition on the user_id property. E.g. "=2" declares that only objects owned by the user with ID 2 are mapped and can hence be queried via SPARQL. You can write any valid SQL (Postgresql) condition here including the operator "=, <, >, ..." and the right hand side of the comparison.
+
+`deploy.sh`  creates a new deployment directory named *iob\/* (in the example above),
 containing these files:
 
 1. *iob.ttl*: The mapping ontology
 1. *iob.obda*: The mappings with adjusted site prefix and URL.
 1. *iob.properties*: Properties file containing the database connection parameters.
 1. *catalog-v001.xml*: 3rd party ontologies imported into *iob.ttl*, in particular the OME core ontology.
-
 
 
 ### Edit properties file
@@ -31,7 +32,6 @@ the postgresql daemon accepts requests. Leave the `jdbc.driver` value as it is.
 
 #### Create read-only OMERO DB user
 Consult *utils/setup_ontop_dbuser.sh* and *queries/sql/ontop_user.sql* to setup the read-only DB user.
-
 
 ### Test setup
 Run
@@ -129,8 +129,12 @@ Don't forget to restart it according to [above](#populate-omero-with-test-data).
 
 ## Acknowledgments
 
-This project was developed with support from the Biohackathon 2024.
-
 <img src="https://2024.biohackathon.org/images/bh24-logo.png" alt="Biohackathon 2024" width="200">
+
+This project was developed with support from the Biohackathon 2024 
+
+This work is further supported by the Deutsche
+Forschungsgemeinschaft (DFG, German Research Foundation) – 501864659
+(NFDI4BIOIMAGE).
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,18 +3,23 @@
 set -e
 
 # Read arguments
-if [ ! $# -eq 2 ]
+if [ ! $# -eq 3 ]
 then
-   echo "Usage: deploy.sh PREFIX URI"
+   echo "Usage: deploy.sh PREFIX URI PUBLICCOND"
+   echo "PREFIX: RDF prefix for site instance, e.g. \"iob\"."
+   echo "URI: URI of site instance including trailing slash or #, e.g. \"https://institute.of.bioimaging.com/\"."
+   echo "PUBLICCOND: SQL Condition on \"user_id\" column that must evaluate to TRUE to map object. E.g. \"=2\" or \">=0\"."
 fi
 
 PREFIX=$1
 SITE=$2
+PUBLICCOND=$3
+
 
 # Function to escape special characters in a string
 ESCSITE=$(echo $SITE | sed -e 's/[]\/$*.^[]/\\&/g')
 
-echo $(escape_regex "$SITE")
+echo $ESCSite
 
 echo "Deploying site $SITE with prefix $PREFIX."
 # Copy ontop dir
@@ -26,7 +31,11 @@ cp -v omero-ontop-mappings/omero-ontop-mappings.ttl ${PREFIX}/${PREFIX}.ttl
 cp -v omero-ontop-mappings/catalog-v001.xml ${PREFIX}/.
 
 # Replace site prefix and URL
-cat omero-ontop-mappings/omero-ontop-mappings.obda | sed "s/ome_instance/${PREFIX}/g" | sed "s/https:\/\/example\.org\/site\//${ESCSITE}/g" > ${PREFIX}/${PREFIX}.obda
+cat omero-ontop-mappings/omero-ontop-mappings.obda | \
+    sed "s/ome_instance/${PREFIX}/g" | \
+    sed "s/https:\/\/example\.org\/site\//${ESCSITE}/g" | \
+    sed "s/owner_id=2/owner_id${PUBLICCOND}/" > \
+    ${PREFIX}/${PREFIX}.obda
 
 # Adjust ontop launch script
 cat omero-ontop-mappings/omero-ontop.sh | sed "s/omero-ontop-mappings/${PREFIX}/g" > ${PREFIX}/${PREFIX}-ontop.sh
@@ -39,6 +48,3 @@ echo ""
 echo "To launch the SPARQL endpoint and query frontend, you can then `cd` into ${PREFIX}/"
 echo "and run the provided script ${PREFIX}-ontop.sh."
 echo ""
-
-
-

--- a/omero-ontop-mappings/omero-ontop-mappings.obda
+++ b/omero-ontop-mappings/omero-ontop-mappings.obda
@@ -19,7 +19,7 @@ ome_instance:	https://example.org/site/
 
 [MappingDeclaration] @collection [[
 mappingId	MAPID-project-0
-target		ome_instance:Project/{project_id} a :Project ; dc:identifier {project_id}^^xsd:integer ; rdfs:label {project_name}^^xsd:string ; rdfs:comment {project_description}^^xsd:string ; this:owner ome_instance:Experimenter/{owner_id} ; this:group ome_instance:ExperimenterGroup/{group_id} ; this:update_id {update_id}^^xsd:integer ; this:creation_id {creation_id}^^xsd:integer . 
+target		ome_instance:Project/{project_id} a :Project ; dc:identifier {project_id}^^xsd:integer ; rdfs:label {project_name}^^xsd:string ; rdfs:comment {project_description}^^xsd:string ; this:owner ome_instance:Experimenter/{owner_id} ; this:group ome_instance:ExperimenterGroup/{group_id} ; this:update_id {update_id}^^xsd:integer ; this:creation_id {creation_id}^^xsd:integer .
 source		select
 			_project.id as project_id,
 			_project.creation_id as creation_id,
@@ -32,7 +32,7 @@ source		select
       where _project.owner_id=2
 
 mappingId	MAPID-project-1
-target		ome_instance:Project/{project_id} a :Project ; this:dataset ome_instance:Dataset/{dataset_id} . 
+target		ome_instance:Project/{project_id} a :Project ; this:dataset ome_instance:Dataset/{dataset_id} .
 source		select
 			_project.id as project_id,
 			_projectdatasetlink.child as dataset_id
@@ -41,7 +41,7 @@ source		select
       where _project.owner_id=2
 
 mappingId	MAPID-project-2
-target		ome_instance:Project/{project_id} a :Project ; <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Project/{project_id} a :Project ; <{map_key}> {map_value}^^xsd:string .
 source		select
 			_project.id as project_id,
 			regexp_replace(
@@ -67,7 +67,7 @@ source		select
       where _project.owner_id=2
 
 mappingId	MAPID-dataset-0
-target		ome_instance:Dataset/{dataset_id} a :Dataset ; dc:identifier {dataset_id}^^xsd:string ; rdfs:label {dataset_name}^^xsd:string ; rdfs:comment {dataset_description}^^xsd:string . 
+target		ome_instance:Dataset/{dataset_id} a :Dataset ; dc:identifier {dataset_id}^^xsd:string ; rdfs:label {dataset_name}^^xsd:string ; rdfs:comment {dataset_description}^^xsd:string .
 source		select
 			_dataset.id as dataset_id,
 			_dataset.name as dataset_name,
@@ -76,7 +76,7 @@ source		select
       where _dataset.owner_id=2
 
 mappingId	MAPID-dataset-2
-target		ome_instance:Dataset/{dataset_id} <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Dataset/{dataset_id} <{map_key}> {map_value}^^xsd:string .
 source		select
 			_dataset.id as dataset_id,
 			_datasetannotationlink.child as annotation_id,
@@ -103,7 +103,7 @@ source		select
       where _dataset.owner_id=2
 
 mappingId	MAPID-Image-0
-target		ome_instance:Image/{image_id} a :Image ; rdfs:label {image_name}^^xsd:string ; rdfs:comment {image_description}^^xsd:string ; this:acquisition_date {image_acquisitiondate}^^xsd:dateTime ; dc:identifier {image_id}^^xsd:integer . 
+target		ome_instance:Image/{image_id} a :Image ; rdfs:label {image_name}^^xsd:string ; rdfs:comment {image_description}^^xsd:string ; this:acquisition_date {image_acquisitiondate}^^xsd:dateTime ; dc:identifier {image_id}^^xsd:integer .
 source		select
 			_image.id as image_id,
 			_image.acquisitiondate as image_acquisitiondate,
@@ -113,7 +113,7 @@ source		select
       where _image.owner_id=2
 
 mappingId	MAPID-Image-1
-target		ome_instance:Image/{image_id} a :Image ; <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Image/{image_id} a :Image ; <{map_key}> {map_value}^^xsd:string .
 source		select
 			_image.id as image_id,
 			regexp_replace(
@@ -139,20 +139,20 @@ source		select
       where _image.owner_id=2
 
 mappingId	MAPID-experimentergroup
-target		ome_instance:ExperimenterGroup/{experimentergroup_id} a :ExperimenterGroup ; dc:identifier {experimentergroup_id}^^xsd:integer ; foaf:name {name}^^xsd:string . 
+target		ome_instance:ExperimenterGroup/{experimentergroup_id} a :ExperimenterGroup ; dc:identifier {experimentergroup_id}^^xsd:integer ; foaf:name {name}^^xsd:string .
 source		select
 			experimentergroup.name as name,
 			experimentergroup.id as experimentergroup_id
 			from experimentergroup ;
 
 mappingId	MAPID-experiment
-target		ome_instance:Experiment/{experiment_id} a :Experiment ; dc:identifier {experiment_id}^^xsd:integer . 
+target		ome_instance:Experiment/{experiment_id} a :Experiment ; dc:identifier {experiment_id}^^xsd:integer .
 source		select
 			experiment.id as experiment_id
 			from experiment ;
 
 mappingId	MAPID-dataset_tag
-target		ome_instance:Dataset/{dataset_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Dataset/{dataset_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			dataset.id as dataset_id,
 			annotation.textvalue as tag_text
@@ -162,7 +162,7 @@ source		select
       and dataset.owner_id=2
 
 mappingId	MAPID-image_tag
-target		ome_instance:Image/{image_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Image/{image_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			image.id as image_id,
 			annotation.textvalue as tag_text
@@ -172,7 +172,7 @@ source		select
       and image.owner_id=2
 
 mappingId	MAPID-project-3
-target		ome_instance:Project/{project_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Project/{project_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			_project.id as project_id,
 			annotation.textvalue as tag_text
@@ -181,11 +181,11 @@ source		select
 			join annotation on projectannotationlink.child = annotation.id where annotation.textvalue is not NULL and _project.owner_id=2
 
 mappingId	MAPID-roi
-target		ome_instance:ROI/{roi_id} a :ROI ; dc:identifier {roi_id}^^xsd:integer ; this:image ome_instance:Image/{roi_image_id} ; this:experimenter ome_instance:Experimenter/{owner_id} . 
+target		ome_instance:ROI/{roi_id} a :ROI ; dc:identifier {roi_id}^^xsd:integer ; this:image ome_instance:Image/{roi_image_id} ; this:experimenter ome_instance:Experimenter/{owner_id} .
 source		select id as roi_id, image as roi_image_id, owner_id from roi where roi.owner_id=2
 
 mappingId	MAPID-dataset-image
-target		ome_instance:Dataset/{dataset_id} a :Dataset ; this:image ome_instance:Image/{image_id} ; dc:identifier {image_id}^^xsd:integer . 
+target		ome_instance:Dataset/{dataset_id} a :Dataset ; this:image ome_instance:Image/{image_id} ; dc:identifier {image_id}^^xsd:integer .
 source		select
 			_dataset.id as dataset_id,
 			_datasetimagelink.child as image_id
@@ -194,31 +194,31 @@ source		select
       where _dataset.owner_id=2
 
 mappingId	MAPID-1c71091abd0f428a83a02cd2ab6fe927
-target		ome_instance:Experimenter/{id} a :Experimenter ; dc:identifier {id}^^xsd:integer ; foaf:firstName {firstname}^^xsd:string ; foaf:lastName {lastname}^^xsd:string ; foaf:email {email}^^xsd:string ; foaf:name {name}^^xsd:string . 
+target		ome_instance:Experimenter/{id} a :Experimenter ; dc:identifier {id}^^xsd:integer ; foaf:firstName {firstname}^^xsd:string ; foaf:lastName {lastname}^^xsd:string ; foaf:email {email}^^xsd:string ; foaf:name {name}^^xsd:string .
 source		select id, email, firstname, middlename, lastname, institution, concat("firstname", ' ', "lastname") as name from experimenter
 
 mappingId	MAPID-image_experimenter
-target		ome_instance:Image/{id} a :Image ; dc:identifier {id}^^xsd:integer ; core:experimenter ome_instance:Experimenter/{owner_id} . 
+target		ome_instance:Image/{id} a :Image ; dc:identifier {id}^^xsd:integer ; core:experimenter ome_instance:Experimenter/{owner_id} .
 source		select id, owner_id from image where image.owner_id=2
 
 mappingId	MAPID-dataset_experimenter
-target		ome_instance:Dataset/{id} a :Dataset ; dc:identifier {id}^^xsd:integer ; core:experimenter ome_instance:Experimenter/{owner_id} . 
+target		ome_instance:Dataset/{id} a :Dataset ; dc:identifier {id}^^xsd:integer ; core:experimenter ome_instance:Experimenter/{owner_id} .
 source		select id, owner_id from dataset where owner_id=2
 
 mappingId	MAPID-project_experimenter
-target		ome_instance:Project/{id} a :Project ; core:experimenter ome_instance:Experimenter/{owner_id} . 
+target		ome_instance:Project/{id} a :Project ; core:experimenter ome_instance:Experimenter/{owner_id} .
 source		select id, owner_id from project where owner_id=2
 
 mappingId	MAPID-well
-target		ome_instance:Well/{well_id} a :Well ; dc:identifier {well_id}^^xsd:integer ; this:experimenter ome_instance:Experimenter/{owner_id} ; this:plate ome_instance:Plate/{plate_id} . 
+target		ome_instance:Well/{well_id} a :Well ; dc:identifier {well_id}^^xsd:integer ; this:experimenter ome_instance:Experimenter/{owner_id} ; this:plate ome_instance:Plate/{plate_id} .
 source		select _well.id as well_id, _well.owner_id as owner_id, _well.plate as plate_id from well as _well where owner_id=2
 
 mappingId	MAPID-well_properties
-target		ome_instance:Well/{well_id} this:reagent ome_instance:Reagent/{reagent_id} . 
+target		ome_instance:Well/{well_id} this:reagent ome_instance:Reagent/{reagent_id} .
 source		select _well.id as well_id, _wellreagentlink.child as reagent_id from well as _well left join wellreagentlink as _wellreagentlink on _well.id = _wellreagentlink.parent where _well.owner_id=2
 
 mappingId	MAPID-well-kvannotations
-target		ome_instance:Well/{well_id} <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Well/{well_id} <{map_key}> {map_value}^^xsd:string .
 source		select _well.id as well_id, regexp_replace(
 			concat(regexp_replace(
 			case
@@ -239,7 +239,7 @@ source		select _well.id as well_id, regexp_replace(
 			left join annotation_mapvalue as _annotation_mapvalue on _annotation.id = _annotation_mapvalue.annotation_id where _well.owner_id=2
 
 mappingId	MAPID-wellsample
-target		ome_instance:WellSample/{wellsample_id} a :WellSample ; dc:identifier {wellsample_id}^^xsd:integer ; this:experimenter ome_instance:Experimenter/{owner_id} ; this:well ome_instance:Well/{well_id} ; this:plate_acquisition ome_instance:PlateAcquisition/{plateacquisition_id} ; this:image ome_instance:Image/{image_id} ; this:well_index {well_index}^^xsd:integer . 
+target		ome_instance:WellSample/{wellsample_id} a :WellSample ; dc:identifier {wellsample_id}^^xsd:integer ; this:experimenter ome_instance:Experimenter/{owner_id} ; this:well ome_instance:Well/{well_id} ; this:plate_acquisition ome_instance:PlateAcquisition/{plateacquisition_id} ; this:image ome_instance:Image/{image_id} ; this:well_index {well_index}^^xsd:integer .
 source		select
 			wellsample.id as wellsample_id,
 			owner_id,
@@ -250,11 +250,11 @@ source		select
 			from wellsample where wellsample.owner_id=2 ;
 
 mappingId	MAPID-281f9aebe6744a7194389d0fcc967623
-target		ome_instance:Plate/{plate_id} a :Plate ; dc:identifier {plate_id}^^xsd:integer ; this:experimenter ome_instance:Experimenter/{plate_owner_id} ; this:screen ome_instance:Screen/{screen_id} . 
+target		ome_instance:Plate/{plate_id} a :Plate ; dc:identifier {plate_id}^^xsd:integer ; this:experimenter ome_instance:Experimenter/{plate_owner_id} ; this:screen ome_instance:Screen/{screen_id} .
 source		select _plate.id as plate_id, _screenplatelink.parent as screen_id, _plate.owner_id as plate_owner_id from plate as _plate left join screenplatelink as _screenplatelink on _plate.id = _screenplatelink.child where _plate.owner_id=2
 
 mappingId	MAPID-plate-kvannotations
-target		ome_instance:Plate/{plate_id} <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Plate/{plate_id} <{map_key}> {map_value}^^xsd:string .
 source		select _plate.id as plate_id, regexp_replace(
 			concat(regexp_replace(
 			case
@@ -276,12 +276,12 @@ source		select _plate.id as plate_id, regexp_replace(
       where _plate.owner_id=2
 
 mappingId	MAPID-281f9aebe6744a7194389d0fcc967624
-target		ome_instance:Screen/{screen_id} a :Screen ; dc:identifier {screen_id}^^xsd:integer ; this:plate ome_instance:Plate/{plate_id} ; this:experimenter ome_instance:Experimenter/{screen_owner_id} . 
+target		ome_instance:Screen/{screen_id} a :Screen ; dc:identifier {screen_id}^^xsd:integer ; this:plate ome_instance:Plate/{plate_id} ; this:experimenter ome_instance:Experimenter/{screen_owner_id} .
 source		select _screen.id as screen_id, _screenplatelink.child as plate_id, _screen.owner_id as screen_owner_id from screen as _screen left join screenplatelink as _screenplatelink on _screen.id = _screenplatelink.parent
       where _screen.owner_id=2
 
 mappingId	MAPID-screen-kvannotations
-target		ome_instance:Screen/{screen_id} <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Screen/{screen_id} <{map_key}> {map_value}^^xsd:string .
 source		select _screen.id as screen_id, regexp_replace(
 			concat(regexp_replace(
 			case
@@ -303,11 +303,11 @@ source		select _screen.id as screen_id, regexp_replace(
       where _screen.owner_id=2
 
 mappingId	MAPID-281f9aebe6744a7194389d0fcc967625
-target		ome_instance:Reagent/{reagent_id} a :Reagent ; dc:identifier {reagent_id}^^xsd:integer . 
+target		ome_instance:Reagent/{reagent_id} a :Reagent ; dc:identifier {reagent_id}^^xsd:integer .
 source		select _reagent.id as reagent_id, _wellreagentlink.parent as well_id from reagent as _reagent left join wellreagentlink as _wellreagentlink on _reagent.id = _wellreagentlink.parent where _reagent.owner_id=2
 
 mappingId	MAPID-reagent-kvannotations
-target		ome_instance:Reagent/{reagent_id} <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:Reagent/{reagent_id} <{map_key}> {map_value}^^xsd:string .
 source		select _reagent.id as reagent_id, regexp_replace(
 			concat(regexp_replace(
 			case
@@ -329,11 +329,11 @@ source		select _reagent.id as reagent_id, regexp_replace(
       where _reagent.owner_id=2
 
 mappingId	MAPID-281f9aebe6744a7194389d0fcc967626
-target		ome_instance:PlateAcquisition/{plate_acquisition_id} a :PlateAcquisition ; dc:identifier {plate_acquisition_id}^^xsd:integer ; this:plate ome_instance:Plate/{plate_id} ; this:experimenter ome_instance:Experimenter/{owner_id} . 
+target		ome_instance:PlateAcquisition/{plate_acquisition_id} a :PlateAcquisition ; dc:identifier {plate_acquisition_id}^^xsd:integer ; this:plate ome_instance:Plate/{plate_id} ; this:experimenter ome_instance:Experimenter/{owner_id} .
 source		select id as plate_acquisition_id, plate as plate_id, owner_id from plateAcquisition where owner_id=2
 
 mappingId	MAPID-PlateAcquisition-kvannotations
-target		ome_instance:PlateAcquisition/{plateacquisition_id} <{map_key}> {map_value}^^xsd:string . 
+target		ome_instance:PlateAcquisition/{plateacquisition_id} <{map_key}> {map_value}^^xsd:string .
 source		select _plateacquisition.id as plateacquisition_id, regexp_replace(
 			concat(regexp_replace(
 			case
@@ -355,7 +355,7 @@ source		select _plateacquisition.id as plateacquisition_id, regexp_replace(
       where _plateacquisition.owner_id=2
 
 mappingId	MAPID-screen-tag
-target		ome_instance:Screen/{screen_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Screen/{screen_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			screen.id as screen_id,
 			annotation.textvalue as tag_text
@@ -364,7 +364,7 @@ source		select
 			join annotation on screenannotationlink.child = annotation.id where annotation.textvalue is not NULL and screen.owner_id=2
 
 mappingId	MAPID-plate-tag
-target		ome_instance:Plate/{plate_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Plate/{plate_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			plate.id as plate_id,
 			annotation.textvalue as tag_text
@@ -373,7 +373,7 @@ source		select
 			join annotation on plateannotationlink.child = annotation.id where annotation.textvalue is not NULL and plate.owner_id=2
 
 mappingId	MAPID-plateacquisition-tag
-target		ome_instance:PlateAcquisition/{plateacquisition_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:PlateAcquisition/{plateacquisition_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			plateacquisition.id as plateacquisition_id,
 			annotation.textvalue as tag_text
@@ -382,7 +382,7 @@ source		select
 			join annotation on plateacquisitionannotationlink.child = annotation.id where annotation.textvalue is not NULL and plateacquisition.owner_id=2
 
 mappingId	MAPID-reagent-tag
-target		ome_instance:Reagent/{reagent_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Reagent/{reagent_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			_reagent.id as reagent_id,
 			annotation.textvalue as tag_text
@@ -391,7 +391,7 @@ source		select
 			join annotation on reagentannotationlink.child = annotation.id where annotation.textvalue is not NULL and _reagent.owner_id=2
 
 mappingId	MAPID-well-tag
-target		ome_instance:Well/{well_id} this:tag_annotation_value {tag_text}^^xsd:string . 
+target		ome_instance:Well/{well_id} this:tag_annotation_value {tag_text}^^xsd:string .
 source		select
 			well.id as well_id,
 			annotation.textvalue as tag_text
@@ -400,11 +400,11 @@ source		select
 			join annotation on wellannotationlink.child = annotation.id where annotation.textvalue is not NULL and well.owner_id=2
 
 mappingId	MAPID-dcf5779a40a44cc4859c65a52285ae28
-target		ome_instance:Channel/{id} a :Channel ; dc:identifier {id}^^xsd:integer ; this:blue {blue}^^xsd:integer ; this:red {red}^^xsd:integer ; this:green {green}^^xsd:integer ; this:pixels ome_instance:Pixels/{pixels_id} . 
+target		ome_instance:Channel/{id} a :Channel ; dc:identifier {id}^^xsd:integer ; this:blue {blue}^^xsd:integer ; this:red {red}^^xsd:integer ; this:green {green}^^xsd:integer ; this:pixels ome_instance:Pixels/{pixels_id} .
 source		select id, alpha, red, green, blue, pixels as pixels_id from channel where channel.owner_id=2
 
 mappingId	MAPID-ada4e8268d2e4546a2578e6aae8ccea6
-target		ome_instance:Pixels/{id} a :Pixels ; this:image ome_instance:Image/{image_id} ; this:physical_size_x {physicalsizex}^^xsd:float ; this:physical_size_x_unit {physicalsizexunit}^^xsd:string ; this:physical_size_y {physicalsizey}^^xsd:float ; this:physical_size_y_unit {physicalsizeyunit}^^xsd:string ; this:physical_size_z {physicalsizez}^^xsd:float ; this:physical_size_z_unit {physicalsizezunit}^^xsd:string . 
+target		ome_instance:Pixels/{id} a :Pixels ; this:image ome_instance:Image/{image_id} ; this:physical_size_x {physicalsizex}^^xsd:float ; this:physical_size_x_unit {physicalsizexunit}^^xsd:string ; this:physical_size_y {physicalsizey}^^xsd:float ; this:physical_size_y_unit {physicalsizeyunit}^^xsd:string ; this:physical_size_z {physicalsizez}^^xsd:float ; this:physical_size_z_unit {physicalsizezunit}^^xsd:string .
 source		select id, image as image_id, physicalsizex, physicalsizexunit, physicalsizey, physicalsizeyunit, physicalsizez, physicalsizezunit from pixels where pixels.owner_id=2
 ]]
 

--- a/omero-ontop-mappings/omero-ontop-mappings.obda
+++ b/omero-ontop-mappings/omero-ontop-mappings.obda
@@ -203,7 +203,7 @@ source		select id, owner_id from image where image.owner_id=2
 
 mappingId	MAPID-dataset_experimenter
 target		ome_instance:Dataset/{id} a :Dataset ; dc:identifier {id}^^xsd:integer ; core:experimenter ome_instance:Experimenter/{owner_id} . 
-source		select id, owner_id from dataset
+source		select id, owner_id from dataset where owner_id=2
 
 mappingId	MAPID-project_experimenter
 target		ome_instance:Project/{id} a :Project ; core:experimenter ome_instance:Experimenter/{owner_id} . 

--- a/omero-ontop-mappings/omero-ontop-mappings.obda
+++ b/omero-ontop-mappings/omero-ontop-mappings.obda
@@ -304,7 +304,7 @@ source		select _screen.id as screen_id, regexp_replace(
 
 mappingId	MAPID-281f9aebe6744a7194389d0fcc967625
 target		ome_instance:Reagent/{reagent_id} a :Reagent ; dc:identifier {reagent_id}^^xsd:integer . 
-source		select _reagent.id as reagent_id, _wellreagentlink.parent as well_id from reagent as _reagent left join wellreagentlink as _wellreagentlink on _reagent.id = _wellreagentlink.parent where reagent.owner_id=2
+source		select _reagent.id as reagent_id, _wellreagentlink.parent as well_id from reagent as _reagent left join wellreagentlink as _wellreagentlink on _reagent.id = _wellreagentlink.parent where _reagent.owner_id=2
 
 mappingId	MAPID-reagent-kvannotations
 target		ome_instance:Reagent/{reagent_id} <{map_key}> {map_value}^^xsd:string . 
@@ -384,11 +384,11 @@ source		select
 mappingId	MAPID-reagent-tag
 target		ome_instance:Reagent/{reagent_id} this:tag_annotation_value {tag_text}^^xsd:string . 
 source		select
-			reagent.id as reagent_id,
+			_reagent.id as reagent_id,
 			annotation.textvalue as tag_text
-			from reagent
-			join reagentannotationlink on reagentannotationlink.parent = reagent.id
-			join annotation on reagentannotationlink.child = annotation.id where annotation.textvalue is not NULL and reagent.owner_id=2
+			from reagent as _reagent
+			join reagentannotationlink on reagentannotationlink.parent = _reagent.id
+			join annotation on reagentannotationlink.child = annotation.id where annotation.textvalue is not NULL and _reagent.owner_id=2
 
 mappingId	MAPID-well-tag
 target		ome_instance:Well/{well_id} this:tag_annotation_value {tag_text}^^xsd:string . 

--- a/omero-ontop-mappings/omero-ontop-mappings.properties
+++ b/omero-ontop-mappings/omero-ontop-mappings.properties
@@ -1,5 +1,5 @@
 #Thu Feb 27 15:56:53 CET 2025
 jdbc.password=\!ontop$
 jdbc.user=ontop
-jdbc.url=jdbc\:postgresql\://localhost\:15432/postgres
+jdbc.url=jdbc\:postgresql\://micropop046\:15432/postgres
 jdbc.driver=org.postgresql.Driver

--- a/queries/sparql/queries.org
+++ b/queries/sparql/queries.org
@@ -326,20 +326,32 @@
 #+end_src
 
 #+RESULTS:
-| ds                          |
-|-----------------------------|
-| http://micropop046/Image/51 |
-| http://micropop046/Image/52 |
-| http://micropop046/Image/53 |
-| http://micropop046/Image/54 |
-| http://micropop046/Image/55 |
-| http://micropop046/Image/56 |
-| http://micropop046/Image/57 |
-| http://micropop046/Image/58 |
-| http://micropop046/Image/59 |
-| http://micropop046/Image/60 |
-| http://micropop046/Image/61 |
-| http://micropop046/Image/62 |
+| ds                           |
+|------------------------------|
+| https://example.org/Image/1  |
+| https://example.org/Image/2  |
+| https://example.org/Image/3  |
+| https://example.org/Image/4  |
+| https://example.org/Image/5  |
+| https://example.org/Image/6  |
+| https://example.org/Image/7  |
+| https://example.org/Image/8  |
+| https://example.org/Image/9  |
+| https://example.org/Image/10 |
+| https://example.org/Image/11 |
+| https://example.org/Image/12 |
+| https://example.org/Image/13 |
+| https://example.org/Image/14 |
+| https://example.org/Image/15 |
+| https://example.org/Image/16 |
+| https://example.org/Image/17 |
+| https://example.org/Image/18 |
+| https://example.org/Image/19 |
+| https://example.org/Image/20 |
+| https://example.org/Image/21 |
+| https://example.org/Image/22 |
+| https://example.org/Image/23 |
+| https://example.org/Image/24 |
 
 ** Image and properties
 :PROPERTIES:
@@ -356,148 +368,148 @@
       #+end_src
 
 #+RESULTS:
-| img                               | prop                                                     | val                                        |
-|-----------------------------------+----------------------------------------------------------+--------------------------------------------|
-| https://example.org/site/Image/13 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/14 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/15 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/16 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/17 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/18 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/19 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/20 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/21 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/22 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/23 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/24 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| https://example.org/site/Image/13 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/14 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/15 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/16 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/17 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/18 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/19 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/20 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/21 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/22 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/23 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/24 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
-| https://example.org/site/Image/13 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:57:45 PM CEST 2025           |
-| https://example.org/site/Image/14 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:57:55 PM CEST 2025           |
-| https://example.org/site/Image/15 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:05 PM CEST 2025           |
-| https://example.org/site/Image/16 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:15 PM CEST 2025           |
-| https://example.org/site/Image/17 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:26 PM CEST 2025           |
-| https://example.org/site/Image/18 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:36 PM CEST 2025           |
-| https://example.org/site/Image/19 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:46 PM CEST 2025           |
-| https://example.org/site/Image/20 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:56 PM CEST 2025           |
-| https://example.org/site/Image/21 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:06 PM CEST 2025           |
-| https://example.org/site/Image/22 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:17 PM CEST 2025           |
-| https://example.org/site/Image/23 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:28 PM CEST 2025           |
-| https://example.org/site/Image/23 | http://purl.org/dc/terms/date                            | Sat Nov  9 11:31:47 PM CET 2024            |
-| https://example.org/site/Image/24 | http://purl.org/dc/terms/date                            | Sat Nov  9 11:31:57 PM CET 2024            |
-| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
-| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
-| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
-| https://example.org/site/Image/13 | http://purl.org/dc/elements/1.1/identifier               | 13                                         |
-| https://example.org/site/Image/14 | http://purl.org/dc/elements/1.1/identifier               | 14                                         |
-| https://example.org/site/Image/15 | http://purl.org/dc/elements/1.1/identifier               | 15                                         |
-| https://example.org/site/Image/16 | http://purl.org/dc/elements/1.1/identifier               | 16                                         |
-| https://example.org/site/Image/17 | http://purl.org/dc/elements/1.1/identifier               | 17                                         |
-| https://example.org/site/Image/18 | http://purl.org/dc/elements/1.1/identifier               | 18                                         |
-| https://example.org/site/Image/19 | http://purl.org/dc/elements/1.1/identifier               | 19                                         |
-| https://example.org/site/Image/20 | http://purl.org/dc/elements/1.1/identifier               | 20                                         |
-| https://example.org/site/Image/21 | http://purl.org/dc/elements/1.1/identifier               | 21                                         |
-| https://example.org/site/Image/22 | http://purl.org/dc/elements/1.1/identifier               | 22                                         |
-| https://example.org/site/Image/23 | http://purl.org/dc/elements/1.1/identifier               | 23                                         |
-| https://example.org/site/Image/24 | http://purl.org/dc/elements/1.1/identifier               | 24                                         |
-| https://example.org/site/Image/13 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-58-36_screenshot.png         |
-| https://example.org/site/Image/14 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-53-28_screenshot.png         |
-| https://example.org/site/Image/15 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-01-36_screenshot.png         |
-| https://example.org/site/Image/16 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-09-28_screenshot.png         |
-| https://example.org/site/Image/17 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png         |
-| https://example.org/site/Image/18 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-07-18_screenshot.png         |
-| https://example.org/site/Image/19 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-17-25_screenshot.png         |
-| https://example.org/site/Image/20 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-39-27_screenshot.png         |
-| https://example.org/site/Image/21 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-47-01_screenshot.png         |
-| https://example.org/site/Image/22 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-42-47_screenshot.png         |
-| https://example.org/site/Image/23 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png.ome.tif |
-| https://example.org/site/Image/24 | http://www.w3.org/2000/01/rdf-schema#label               | image_6_with_roi.ome.tif                   |
-| https://example.org/site/Image/13 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/14 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/15 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/16 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/17 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/18 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/19 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/20 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/21 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/22 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/23 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
-| https://example.org/site/Image/23 | http://purl.org/dc/terms/contributor                     | Test User                                  |
-| https://example.org/site/Image/24 | http://purl.org/dc/terms/contributor                     | Test User                                  |
-| https://example.org/site/Image/13 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/14 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/15 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/16 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/17 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/18 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/19 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/20 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/21 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/22 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/23 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
-| https://example.org/site/Image/23 | http://purl.org/dc/terms/subject                         | Unittest                                   |
-| https://example.org/site/Image/24 | http://purl.org/dc/terms/subject                         | Unittest                                   |
-| https://example.org/site/Image/24 | http://www.openmicroscopy.org/ns/default/annotator       | Public MrX                                 |
-| https://example.org/site/Image/21 | http://www.openmicroscopy.org/ns/default/Assay           | Bruker                                     |
-| https://example.org/site/Image/22 | http://www.openmicroscopy.org/ns/default/Assay           | PRTSC                                      |
-| https://example.org/site/Image/23 | http://www.openmicroscopy.org/ns/default/sampletype      | Public screen                              |
+| img                      | prop                                                     | val                                        |
+|--------------------------+----------------------------------------------------------+--------------------------------------------|
+| http://test.com/Image/13 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/14 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/15 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/16 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/17 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/18 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/19 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/20 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/21 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/22 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/23 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/24 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://test.com/Image/13 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/14 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/15 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/16 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/17 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/18 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/19 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/20 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/21 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/22 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/23 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/24 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://test.com/Image/13 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/14 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/15 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/16 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/17 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/18 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/19 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/20 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/21 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/22 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/23 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/24 | https://ld.openmicroscopy.org/core/experimenter          | http://test.com/Experimenter/2             |
+| http://test.com/Image/13 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/14 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/15 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/16 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/17 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/18 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/19 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/20 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/21 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/22 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/23 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/24 | https://ld.openmicroscopy.org/omekg#experimenter         | http://test.com/Experimenter/2             |
+| http://test.com/Image/13 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/14 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/15 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/16 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/17 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/18 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/19 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/20 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/21 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/22 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/23 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/24 | https://ld.openmicroscopy.org/omekg#owner                | http://test.com/Experimenter/2             |
+| http://test.com/Image/13 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:57:45 PM CEST 2025           |
+| http://test.com/Image/14 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:57:55 PM CEST 2025           |
+| http://test.com/Image/15 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:05 PM CEST 2025           |
+| http://test.com/Image/16 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:15 PM CEST 2025           |
+| http://test.com/Image/17 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:26 PM CEST 2025           |
+| http://test.com/Image/18 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:36 PM CEST 2025           |
+| http://test.com/Image/19 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:46 PM CEST 2025           |
+| http://test.com/Image/20 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:56 PM CEST 2025           |
+| http://test.com/Image/21 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:06 PM CEST 2025           |
+| http://test.com/Image/22 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:17 PM CEST 2025           |
+| http://test.com/Image/23 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:28 PM CEST 2025           |
+| http://test.com/Image/23 | http://purl.org/dc/terms/date                            | Sat Nov  9 11:31:47 PM CET 2024            |
+| http://test.com/Image/24 | http://purl.org/dc/terms/date                            | Sat Nov  9 11:31:57 PM CET 2024            |
+| http://test.com/Image/13 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/14 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/15 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/16 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/17 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/18 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/19 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/20 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/21 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/22 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/23 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| http://test.com/Image/23 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
+| http://test.com/Image/24 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
+| http://test.com/Image/13 | http://purl.org/dc/elements/1.1/identifier               | 13                                         |
+| http://test.com/Image/14 | http://purl.org/dc/elements/1.1/identifier               | 14                                         |
+| http://test.com/Image/15 | http://purl.org/dc/elements/1.1/identifier               | 15                                         |
+| http://test.com/Image/16 | http://purl.org/dc/elements/1.1/identifier               | 16                                         |
+| http://test.com/Image/17 | http://purl.org/dc/elements/1.1/identifier               | 17                                         |
+| http://test.com/Image/18 | http://purl.org/dc/elements/1.1/identifier               | 18                                         |
+| http://test.com/Image/19 | http://purl.org/dc/elements/1.1/identifier               | 19                                         |
+| http://test.com/Image/20 | http://purl.org/dc/elements/1.1/identifier               | 20                                         |
+| http://test.com/Image/21 | http://purl.org/dc/elements/1.1/identifier               | 21                                         |
+| http://test.com/Image/22 | http://purl.org/dc/elements/1.1/identifier               | 22                                         |
+| http://test.com/Image/23 | http://purl.org/dc/elements/1.1/identifier               | 23                                         |
+| http://test.com/Image/24 | http://purl.org/dc/elements/1.1/identifier               | 24                                         |
+| http://test.com/Image/13 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-58-36_screenshot.png         |
+| http://test.com/Image/14 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-53-28_screenshot.png         |
+| http://test.com/Image/15 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-01-36_screenshot.png         |
+| http://test.com/Image/16 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-09-28_screenshot.png         |
+| http://test.com/Image/17 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png         |
+| http://test.com/Image/18 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-07-18_screenshot.png         |
+| http://test.com/Image/19 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-17-25_screenshot.png         |
+| http://test.com/Image/20 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-39-27_screenshot.png         |
+| http://test.com/Image/21 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-47-01_screenshot.png         |
+| http://test.com/Image/22 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-42-47_screenshot.png         |
+| http://test.com/Image/23 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png.ome.tif |
+| http://test.com/Image/24 | http://www.w3.org/2000/01/rdf-schema#label               | image_6_with_roi.ome.tif                   |
+| http://test.com/Image/13 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/14 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/15 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/16 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/17 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/18 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/19 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/20 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/21 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/22 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/23 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| http://test.com/Image/23 | http://purl.org/dc/terms/contributor                     | Test User                                  |
+| http://test.com/Image/24 | http://purl.org/dc/terms/contributor                     | Test User                                  |
+| http://test.com/Image/13 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/14 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/15 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/16 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/17 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/18 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/19 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/20 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/21 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/22 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/23 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| http://test.com/Image/23 | http://purl.org/dc/terms/subject                         | Unittest                                   |
+| http://test.com/Image/24 | http://purl.org/dc/terms/subject                         | Unittest                                   |
+| http://test.com/Image/24 | http://www.openmicroscopy.org/ns/default/annotator       | Public MrX                                 |
+| http://test.com/Image/21 | http://www.openmicroscopy.org/ns/default/Assay           | Bruker                                     |
+| http://test.com/Image/22 | http://www.openmicroscopy.org/ns/default/Assay           | PRTSC                                      |
+| http://test.com/Image/23 | http://www.openmicroscopy.org/ns/default/sampletype      | Public screen                              |
 
 ** Image and DC metadata terms
 :PROPERTIES:
@@ -506,32 +518,31 @@
 #+begin_src sparql
   prefix ome_core: <https://ld.openmicroscopy.org/core/>
   prefix dc: <http://purl.org/dc/terms/>
+  prefix omekg: <https://ld.openmicroscopy.org/omekg/>
 
   SELECT distinct ?img ?author ?subject WHERE {
     ?img a ome_core:Image;
-         dc:contributor ?author;
-         dc:subject ?subject .
+         # omekg:owner ?owner;
+         # dc:contributor ?author;
+         # dc:subject ?subject .
     }
       #+end_src
 
 #+RESULTS:
-| img                               | author           | subject         |
-|-----------------------------------+------------------+-----------------|
-| https://example.org/site/Image/13 | Public Test User | Public Unittest |
-| https://example.org/site/Image/14 | Public Test User | Public Unittest |
-| https://example.org/site/Image/15 | Public Test User | Public Unittest |
-| https://example.org/site/Image/16 | Public Test User | Public Unittest |
-| https://example.org/site/Image/17 | Public Test User | Public Unittest |
-| https://example.org/site/Image/18 | Public Test User | Public Unittest |
-| https://example.org/site/Image/19 | Public Test User | Public Unittest |
-| https://example.org/site/Image/20 | Public Test User | Public Unittest |
-| https://example.org/site/Image/21 | Public Test User | Public Unittest |
-| https://example.org/site/Image/22 | Public Test User | Public Unittest |
-| https://example.org/site/Image/23 | Public Test User | Public Unittest |
-| https://example.org/site/Image/23 | Public Test User | Unittest        |
-| https://example.org/site/Image/23 | Test User        | Public Unittest |
-| https://example.org/site/Image/23 | Test User        | Unittest        |
-| https://example.org/site/Image/24 | Test User        | Unittest        |
+| img                      | author | subject |
+|--------------------------+--------+---------|
+| http://test.com/Image/13 |        |         |
+| http://test.com/Image/14 |        |         |
+| http://test.com/Image/15 |        |         |
+| http://test.com/Image/16 |        |         |
+| http://test.com/Image/17 |        |         |
+| http://test.com/Image/18 |        |         |
+| http://test.com/Image/19 |        |         |
+| http://test.com/Image/20 |        |         |
+| http://test.com/Image/21 |        |         |
+| http://test.com/Image/22 |        |         |
+| http://test.com/Image/23 |        |         |
+| http://test.com/Image/24 |        |         |
 
 ** Dataset number of type relations
 :PROPERTIES:

--- a/queries/sparql/queries.org
+++ b/queries/sparql/queries.org
@@ -114,7 +114,11 @@
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
-#+begin_src sparql :url http://localhost:8080/sparql
+** List all datasets
+:PROPERTIES:
+:ID:       eda1ed27-583d-4637-bc2b-c8795a408c9b
+:END:
+#+begin_src sparql :url http://micropop046:8080/sparql
   PREFIX : <https://www.openmicroscopy.org/omemap/>
   PREFIX owl: <http://www.w3.org/2002/07/owl#>
   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -123,7 +127,7 @@
   PREFIX obda: <https://w3id.org/obda/vocabulary#>
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
-  PREFIX ome_core: <http://www.openmicroscopy.org/rdf/2016-06/ome_core/>
+  prefix ome_core: <https://ld.openmicroscopy.org/core/>
 
   select ?ds where {
   ?ds a ome_core:Dataset .
@@ -134,9 +138,45 @@
 #+RESULTS:
 | ds                                 |
 |------------------------------------|
-| https://example.org/site/Dataset/3 |
-| https://example.org/site/Dataset/2 |
 | https://example.org/site/Dataset/1 |
+| https://example.org/site/Dataset/2 |
+| https://example.org/site/Dataset/3 |
+| https://example.org/site/Dataset/4 |
+| https://example.org/site/Dataset/5 |
+| https://example.org/site/Dataset/6 |
+
+** datasets and properties
+:PROPERTIES:
+:ID:       ffeb2f65-35a2-40b6-af88-820caf58ffa8
+:END:
+#+begin_src sparql :url http://localhost:8080/sparql
+  PREFIX : <https://www.openmicroscopy.org/omemap/>
+  PREFIX owl: <http://www.w3.org/2002/07/owl#>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX xml: <http://www.w3.org/XML/1998/namespace>
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX obda: <https://w3id.org/obda/vocabulary#>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
+  prefix ome_core: <https://ld.openmicroscopy.org/core/>
+  prefix omekg: <https://ld.openmicroscopy.org/omekg#>
+
+  select * where {
+  ?ds a ome_core:Dataset ;
+      omekg:owner ?owner .
+  }
+  order by ?owner
+#+end_src
+
+#+RESULTS:
+| ds                                          | owner                                            |
+|---------------------------------------------+--------------------------------------------------|
+| http://micropop046.evolbio.mpg.de/Dataset/1 | http://micropop046.evolbio.mpg.de/Experimenter/0 |
+| http://micropop046.evolbio.mpg.de/Dataset/3 | http://micropop046.evolbio.mpg.de/Experimenter/0 |
+| http://micropop046.evolbio.mpg.de/Dataset/2 | http://micropop046.evolbio.mpg.de/Experimenter/0 |
+| http://micropop046.evolbio.mpg.de/Dataset/5 | http://micropop046.evolbio.mpg.de/Experimenter/2 |
+| http://micropop046.evolbio.mpg.de/Dataset/4 | http://micropop046.evolbio.mpg.de/Experimenter/2 |
+| http://micropop046.evolbio.mpg.de/Dataset/6 | http://micropop046.evolbio.mpg.de/Experimenter/2 |
 
 * Dataset II
 :PROPERTIES:

--- a/queries/sparql/queries.org
+++ b/queries/sparql/queries.org
@@ -101,10 +101,10 @@
 #+end_src
 
 #+RESULTS:
-| project                      | typ                                         |
-|------------------------------+---------------------------------------------|
-| http://micropop046/Project/2 | https://ld.openmicroscopy.org/core/Project  |
-| http://micropop046/Project/2 | https://ld.openmicroscopy.org/omekg/Project |
+| project                       | typ                                         |
+|-------------------------------+---------------------------------------------|
+| http://micropop046/Project/52 | https://ld.openmicroscopy.org/core/Project  |
+| http://micropop046/Project/52 | https://ld.openmicroscopy.org/omekg/Project |
 
 ** Dataset
 :PROPERTIES:
@@ -267,7 +267,7 @@
 | https://example.org/site/Project/1 | https://example.org/site/Dataset/2 | https://example.org/site/Image/6  | 2024-10-10_15-09-28_screenshot.png         |
 | https://example.org/site/Project/1 | https://example.org/site/Dataset/2 | https://example.org/site/Image/4  | 2024-10-10_15-28-16_screenshot.png         |
 
-** Image with owner
+** Image with ROI
 :PROPERTIES:
 :ID:       c856598c-c952-4964-b4b2-40b4a1269afc
 :END:
@@ -290,8 +290,20 @@
   #+end_src
 
 #+RESULTS:
-| img | roi |
-|-----+-----|
+| img                         | roi |
+|-----------------------------+-----|
+| http://micropop046/Image/51 |     |
+| http://micropop046/Image/52 |     |
+| http://micropop046/Image/53 |     |
+| http://micropop046/Image/54 |     |
+| http://micropop046/Image/55 |     |
+| http://micropop046/Image/56 |     |
+| http://micropop046/Image/57 |     |
+| http://micropop046/Image/58 |     |
+| http://micropop046/Image/59 |     |
+| http://micropop046/Image/60 |     |
+| http://micropop046/Image/61 |     |
+| http://micropop046/Image/62 |     |
 
 ** Image with owner
 :PROPERTIES:
@@ -306,17 +318,133 @@
   PREFIX obda: <https://w3id.org/obda/vocabulary#>
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
-  PREFIX ome_core: <http://www.openmicroscopy.org/rdf/2016-06/ome_core/>
+  PREFIX ome_core: <https://ld.openmicroscopy.org/core/>
   prefix vcard: <https://www.w3.org/2006/vcard/ns#>
   select distinct * where {
   ?ds a ome_core:Image .
-  ?ds ome_core:experimenterGroup ?owner .
   }
 #+end_src
 
 #+RESULTS:
-| ds | owner |
-|----+-------|
+| ds                          |
+|-----------------------------|
+| http://micropop046/Image/51 |
+| http://micropop046/Image/52 |
+| http://micropop046/Image/53 |
+| http://micropop046/Image/54 |
+| http://micropop046/Image/55 |
+| http://micropop046/Image/56 |
+| http://micropop046/Image/57 |
+| http://micropop046/Image/58 |
+| http://micropop046/Image/59 |
+| http://micropop046/Image/60 |
+| http://micropop046/Image/61 |
+| http://micropop046/Image/62 |
+
+** Image and properties
+:PROPERTIES:
+:ID:       f9c6719d-7aad-460a-8200-def2533884dd
+:END:
+#+begin_src sparql
+  prefix ome_core: <https://ld.openmicroscopy.org/core/>
+  prefix dc: <http://purl.org/dc/terms/>
+
+  SELECT distinct ?img ?prop ?val WHERE {
+    ?img a ome_core:Image;
+         ?prop ?val .
+    }
+      #+end_src
+
+#+RESULTS:
+| img                         | prop                                                     | val                                        |
+|-----------------------------+----------------------------------------------------------+--------------------------------------------|
+| http://micropop046/Image/51 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/52 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/53 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/54 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/55 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/56 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/57 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/58 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/59 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/60 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/61 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/62 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| http://micropop046/Image/51 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/52 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/53 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/54 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/55 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/56 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/57 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/58 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/59 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/60 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/61 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/62 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| http://micropop046/Image/51 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/52 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/53 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/54 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/55 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/56 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/57 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/58 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/59 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/60 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/61 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/62 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/51 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/52 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/53 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/54 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/55 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/56 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/57 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/58 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/59 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/60 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/61 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/62 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/51 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/52 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/53 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/54 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/55 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/56 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/57 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/58 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/59 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/60 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/61 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/62 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
+| http://micropop046/Image/61 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
+| http://micropop046/Image/62 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
+| http://micropop046/Image/51 | http://purl.org/dc/elements/1.1/identifier               | 51                                         |
+| http://micropop046/Image/52 | http://purl.org/dc/elements/1.1/identifier               | 52                                         |
+| http://micropop046/Image/53 | http://purl.org/dc/elements/1.1/identifier               | 53                                         |
+| http://micropop046/Image/54 | http://purl.org/dc/elements/1.1/identifier               | 54                                         |
+| http://micropop046/Image/55 | http://purl.org/dc/elements/1.1/identifier               | 55                                         |
+| http://micropop046/Image/56 | http://purl.org/dc/elements/1.1/identifier               | 56                                         |
+| http://micropop046/Image/57 | http://purl.org/dc/elements/1.1/identifier               | 57                                         |
+| http://micropop046/Image/58 | http://purl.org/dc/elements/1.1/identifier               | 58                                         |
+| http://micropop046/Image/59 | http://purl.org/dc/elements/1.1/identifier               | 59                                         |
+| http://micropop046/Image/60 | http://purl.org/dc/elements/1.1/identifier               | 60                                         |
+| http://micropop046/Image/61 | http://purl.org/dc/elements/1.1/identifier               | 61                                         |
+| http://micropop046/Image/62 | http://purl.org/dc/elements/1.1/identifier               | 62                                         |
+| http://micropop046/Image/51 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-58-36_screenshot.png         |
+| http://micropop046/Image/52 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-53-28_screenshot.png         |
+| http://micropop046/Image/53 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-01-36_screenshot.png         |
+| http://micropop046/Image/54 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-09-28_screenshot.png         |
+| http://micropop046/Image/55 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png         |
+| http://micropop046/Image/56 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-07-18_screenshot.png         |
+| http://micropop046/Image/57 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-17-25_screenshot.png         |
+| http://micropop046/Image/58 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-39-27_screenshot.png         |
+| http://micropop046/Image/59 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-47-01_screenshot.png         |
+| http://micropop046/Image/60 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-42-47_screenshot.png         |
+| http://micropop046/Image/61 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png.ome.tif |
+| http://micropop046/Image/62 | http://www.w3.org/2000/01/rdf-schema#label               | image_6_with_roi.ome.tif                   |
+
 
 ** Dataset number of type relations
 :PROPERTIES:

--- a/queries/sparql/queries.org
+++ b/queries/sparql/queries.org
@@ -1,31 +1,4 @@
-* Project
-:PROPERTIES:
-:ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
-:END:
-#+begin_src sparql :url http://localhost:8080/sparql
-  PREFIX : <https://www.openmicroscopy.org/omemap/>
-  PREFIX owl: <http://www.w3.org/2002/07/owl#>
-  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-  PREFIX xml: <http://www.w3.org/XML/1998/namespace>
-  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-  PREFIX obda: <https://w3id.org/obda/vocabulary#>
-  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-  PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
-  PREFIX ome_core: <http://www.openmicroscopy.org/rdf/2016-06/ome_core/>
-
-  select distinct  ?project ?typ where {
-  ?project a ome_core:Project ;
-      rdf:type ?typ ;
-  }
-  limit 10
-#+end_src
-
-#+RESULTS:
-| ds                                 | tp                                                         |
-|------------------------------------+------------------------------------------------------------|
-| https://example.org/site/Project/1 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/Project |
-
-* Project remote host
+* Queries against micropop046
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
@@ -80,45 +53,68 @@
 #+RESULTS:
 | project                            | prop                                                   | val                                          |
 |------------------------------------+--------------------------------------------------------+----------------------------------------------|
-| https://example.org/site/Project/1 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/1           |
 | https://example.org/site/Project/2 | http://purl.org/dc/elements/1.1/identifier             | 2                                            |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#update_id          | 820                                          |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/6           |
-| https://example.org/site/Project/1 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/3           |
-| https://example.org/site/Project/1 | http://purl.org/dc/terms/subject                       | OMERO Ontology                               |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#experimenter       | https://example.org/site/Experimenter/2      |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/core/experimenter_group  | https://example.org/site/ExperimenterGroup/3 |
-| https://example.org/site/Project/1 | https://ld.openmicroscopy.org/omekg#experimenter       | https://example.org/site/Experimenter/0      |
-| https://example.org/site/Project/1 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/2           |
-| https://example.org/site/Project/2 | http://purl.org/dc/terms/provenance                    | Test Data                                    |
-| https://example.org/site/Project/1 | https://ld.openmicroscopy.org/core/experimenter        | https://example.org/site/Experimenter/0      |
-| https://example.org/site/Project/2 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type        | https://ld.openmicroscopy.org/core/Project   |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#owner              | https://example.org/site/Experimenter/2      |
-| https://example.org/site/Project/1 | https://ld.openmicroscopy.org/omekg#owner              | https://example.org/site/Experimenter/0      |
-| https://example.org/site/Project/1 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type        | https://ld.openmicroscopy.org/core/Project   |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#creation_id        | 738                                          |
-| https://example.org/site/Project/2 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type        | https://ld.openmicroscopy.org/omekg/Project  |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/4           |
-| https://example.org/site/Project/1 | http://purl.org/dc/terms/provenance                    | Test Data                                    |
-| https://example.org/site/Project/1 | http://purl.org/dc/terms/contributor                   | Nophretete                                   |
 | https://example.org/site/Project/2 | http://purl.org/dc/terms/contributor                   | Nophretete                                   |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#experimenter_group | https://example.org/site/ExperimenterGroup/3 |
-| https://example.org/site/Project/1 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type        | https://ld.openmicroscopy.org/omekg/Project  |
+| https://example.org/site/Project/2 | http://purl.org/dc/terms/provenance                    | Test Data                                    |
 | https://example.org/site/Project/2 | http://purl.org/dc/terms/subject                       | OMERO Ontology                               |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#group              | https://example.org/site/ExperimenterGroup/3 |
-| https://example.org/site/Project/2 | http://www.w3.org/2000/01/rdf-schema#label             | Public Project                               |
-| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/5           |
 | https://example.org/site/Project/2 | https://ld.openmicroscopy.org/core/experimenter        | https://example.org/site/Experimenter/2      |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/core/experimenter_group  | https://example.org/site/ExperimenterGroup/3 |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#creation_id        | 738                                          |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/4           |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/5           |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#dataset            | https://example.org/site/Dataset/6           |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#experimenter       | https://example.org/site/Experimenter/2      |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#experimenter_group | https://example.org/site/ExperimenterGroup/3 |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#group              | https://example.org/site/ExperimenterGroup/3 |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#owner              | https://example.org/site/Experimenter/2      |
+| https://example.org/site/Project/2 | https://ld.openmicroscopy.org/omekg#update_id          | 820                                          |
+| https://example.org/site/Project/2 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type        | https://ld.openmicroscopy.org/core/Project   |
+| https://example.org/site/Project/2 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type        | https://ld.openmicroscopy.org/omekg/Project  |
+| https://example.org/site/Project/2 | http://www.w3.org/2000/01/rdf-schema#label             | Public Project                               |
 
-* Dataset 
+* Queries against localhost
+:PROPERTIES:
+:ID:       059e06f4-bd2b-4ec1-8280-7c25d62a66fa
+:header-args:sparql: :url http://localhost:8080/sparql :cache nil
+:END:
+
+** Project
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
-** List all datasets
+#+begin_src sparql
+  PREFIX : <https://www.openmicroscopy.org/omemap/>
+  PREFIX owl: <http://www.w3.org/2002/07/owl#>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX xml: <http://www.w3.org/XML/1998/namespace/>
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+  PREFIX obda: <https://w3id.org/obda/vocabulary#>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+  PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
+  PREFIX ome_core: <https://ld.openmicroscopy.org/core/>
+
+  select distinct  ?project ?typ where {
+  ?project a ome_core:Project ;
+      rdf:type ?typ ;
+  }
+  limit 10
+#+end_src
+
+#+RESULTS:
+| project                      | typ                                         |
+|------------------------------+---------------------------------------------|
+| http://micropop046/Project/2 | https://ld.openmicroscopy.org/core/Project  |
+| http://micropop046/Project/2 | https://ld.openmicroscopy.org/omekg/Project |
+
+** Dataset
+:PROPERTIES:
+:ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
+:END:
+*** List all datasets
 :PROPERTIES:
 :ID:       eda1ed27-583d-4637-bc2b-c8795a408c9b
 :END:
-#+begin_src sparql :url http://micropop046:8080/sparql
+#+begin_src sparql
   PREFIX : <https://www.openmicroscopy.org/omemap/>
   PREFIX owl: <http://www.w3.org/2002/07/owl#>
   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -136,20 +132,20 @@
 #+end_src
 
 #+RESULTS:
-| ds                                 |
-|------------------------------------|
-| https://example.org/site/Dataset/1 |
-| https://example.org/site/Dataset/2 |
-| https://example.org/site/Dataset/3 |
-| https://example.org/site/Dataset/4 |
-| https://example.org/site/Dataset/5 |
-| https://example.org/site/Dataset/6 |
+| ds                           |
+|------------------------------|
+| http://micropop046/Dataset/1 |
+| http://micropop046/Dataset/2 |
+| http://micropop046/Dataset/3 |
+| http://micropop046/Dataset/4 |
+| http://micropop046/Dataset/5 |
+| http://micropop046/Dataset/6 |
 
-** datasets and properties
+*** datasets and properties
 :PROPERTIES:
 :ID:       ffeb2f65-35a2-40b6-af88-820caf58ffa8
 :END:
-#+begin_src sparql :url http://localhost:8080/sparql
+#+begin_src sparql
   PREFIX : <https://www.openmicroscopy.org/omemap/>
   PREFIX owl: <http://www.w3.org/2002/07/owl#>
   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -169,16 +165,16 @@
 #+end_src
 
 #+RESULTS:
-| ds                                          | owner                                            |
-|---------------------------------------------+--------------------------------------------------|
-| http://micropop046.evolbio.mpg.de/Dataset/1 | http://micropop046.evolbio.mpg.de/Experimenter/0 |
-| http://micropop046.evolbio.mpg.de/Dataset/3 | http://micropop046.evolbio.mpg.de/Experimenter/0 |
-| http://micropop046.evolbio.mpg.de/Dataset/2 | http://micropop046.evolbio.mpg.de/Experimenter/0 |
-| http://micropop046.evolbio.mpg.de/Dataset/5 | http://micropop046.evolbio.mpg.de/Experimenter/2 |
-| http://micropop046.evolbio.mpg.de/Dataset/4 | http://micropop046.evolbio.mpg.de/Experimenter/2 |
-| http://micropop046.evolbio.mpg.de/Dataset/6 | http://micropop046.evolbio.mpg.de/Experimenter/2 |
+| ds                           | owner                             |
+|------------------------------+-----------------------------------|
+| http://micropop046/Dataset/2 | http://micropop046/Experimenter/0 |
+| http://micropop046/Dataset/3 | http://micropop046/Experimenter/0 |
+| http://micropop046/Dataset/1 | http://micropop046/Experimenter/0 |
+| http://micropop046/Dataset/5 | http://micropop046/Experimenter/2 |
+| http://micropop046/Dataset/4 | http://micropop046/Experimenter/2 |
+| http://micropop046/Dataset/6 | http://micropop046/Experimenter/2 |
 
-* Dataset II
+** Dataset II
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
@@ -191,7 +187,7 @@
   PREFIX obda: <https://w3id.org/obda/vocabulary#>
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
-  PREFIX ome_core: <http://www.openmicroscopy.org/rdf/2016-06/ome_core/>
+  PREFIX ome_core: <https://ld.openmicroscopy.org/core/>
 
   select distinct * where {
   ?ds a ome_core:Dataset .
@@ -200,36 +196,44 @@
 #+end_src
 
 #+RESULTS:
-| ds                                 | prop                                                                  | value                                                      |
-|------------------------------------+-----------------------------------------------------------------------+------------------------------------------------------------|
-| https://example.org/site/Dataset/1 | http://www.w3.org/2000/01/rdf-schema#label                            | Dataset 1                                                  |
-| https://example.org/site/Dataset/1 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/1                           |
-| https://example.org/site/Dataset/1 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/2                           |
-| https://example.org/site/Dataset/1 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type                       | http://www.openmicroscopy.org/rdf/2016-06/ome_core/Dataset |
-| https://example.org/site/Dataset/1 | http://purl.org/dc/terms/provenance                                   | Screenshots                                                |
-| https://example.org/site/Dataset/1 | http://purl.org/dc/terms/subject                                      | Test images                                                |
-| https://example.org/site/Dataset/1 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/tagAnnotationValue | TestTag                                                    |
-| https://example.org/site/Dataset/1 | http://purl.org/dc/terms/contributor                                  | Test User                                                  |
-| https://example.org/site/Dataset/2 | http://www.w3.org/2000/01/rdf-schema#label                            | Dataset 2                                                  |
-| https://example.org/site/Dataset/2 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/3                           |
-| https://example.org/site/Dataset/2 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/4                           |
-| https://example.org/site/Dataset/2 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/5                           |
-| https://example.org/site/Dataset/2 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/6                           |
-| https://example.org/site/Dataset/2 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/7                           |
-| https://example.org/site/Dataset/2 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type                       | http://www.openmicroscopy.org/rdf/2016-06/ome_core/Dataset |
-| https://example.org/site/Dataset/2 | http://purl.org/dc/terms/provenance                                   | Screenshots                                                |
-| https://example.org/site/Dataset/2 | http://purl.org/dc/terms/subject                                      | Test images                                                |
-| https://example.org/site/Dataset/2 | http://purl.org/dc/terms/contributor                                  | Test User                                                  |
-| https://example.org/site/Dataset/3 | http://purl.org/dc/terms/contributor                                  | Caligula                                                   |
-| https://example.org/site/Dataset/3 | http://www.w3.org/2000/01/rdf-schema#label                            | Dataset 3                                                  |
-| https://example.org/site/Dataset/3 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/10                          |
-| https://example.org/site/Dataset/3 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/8                           |
-| https://example.org/site/Dataset/3 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/image              | https://example.org/site/Image/9                           |
-| https://example.org/site/Dataset/3 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type                       | http://www.openmicroscopy.org/rdf/2016-06/ome_core/Dataset |
-| https://example.org/site/Dataset/3 | http://purl.org/dc/terms/subject                                      | OMERO Mapping                                              |
-| https://example.org/site/Dataset/3 | http://purl.org/dc/terms/provenance                                   | Screenshots                                                |
+| ds                           | prop                                                     | value                                       |
+|------------------------------+----------------------------------------------------------+---------------------------------------------|
+| http://micropop046/Dataset/4 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Dataset  |
+| http://micropop046/Dataset/5 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Dataset  |
+| http://micropop046/Dataset/6 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Dataset  |
+| http://micropop046/Dataset/4 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Dataset |
+| http://micropop046/Dataset/5 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Dataset |
+| http://micropop046/Dataset/6 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Dataset |
+| http://micropop046/Dataset/4 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/5 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/6 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/4 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/5 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/6 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/4 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/5 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/6 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2           |
+| http://micropop046/Dataset/4 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | TestTag                                     |
+| http://micropop046/Dataset/4 | http://purl.org/dc/elements/1.1/identifier               | 4                                           |
+| http://micropop046/Dataset/5 | http://purl.org/dc/elements/1.1/identifier               | 5                                           |
+| http://micropop046/Dataset/6 | http://purl.org/dc/elements/1.1/identifier               | 6                                           |
+| http://micropop046/Dataset/4 | http://purl.org/dc/elements/1.1/identifier               | 4                                           |
+| http://micropop046/Dataset/5 | http://purl.org/dc/elements/1.1/identifier               | 5                                           |
+| http://micropop046/Dataset/6 | http://purl.org/dc/elements/1.1/identifier               | 6                                           |
+| http://micropop046/Dataset/4 | http://www.w3.org/2000/01/rdf-schema#label               | Dataset 1                                   |
+| http://micropop046/Dataset/5 | http://www.w3.org/2000/01/rdf-schema#label               | Dataset 2                                   |
+| http://micropop046/Dataset/6 | http://www.w3.org/2000/01/rdf-schema#label               | Dataset 3                                   |
+| http://micropop046/Dataset/4 | http://purl.org/dc/terms/contributor                     | Public User                                 |
+| http://micropop046/Dataset/5 | http://purl.org/dc/terms/contributor                     | Public User                                 |
+| http://micropop046/Dataset/6 | http://purl.org/dc/terms/contributor                     | Caligula                                    |
+| http://micropop046/Dataset/4 | http://purl.org/dc/terms/provenance                      | Public Screenshots                          |
+| http://micropop046/Dataset/5 | http://purl.org/dc/terms/provenance                      | Public Screenshots                          |
+| http://micropop046/Dataset/6 | http://purl.org/dc/terms/provenance                      | Screenshots                                 |
+| http://micropop046/Dataset/4 | http://purl.org/dc/terms/subject                         | Public Test images                          |
+| http://micropop046/Dataset/5 | http://purl.org/dc/terms/subject                         | Public Test images                          |
+| http://micropop046/Dataset/6 | http://purl.org/dc/terms/subject                         | OMERO Mapping                               |
 
-* Project Dataset Image hierarchy
+** Project Dataset Image hierarchy
 :PROPERTIES:
 :ID:       9a7fae93-80a0-4cf9-b889-a60113b9bf01
 :END:
@@ -263,11 +267,11 @@
 | https://example.org/site/Project/1 | https://example.org/site/Dataset/2 | https://example.org/site/Image/6  | 2024-10-10_15-09-28_screenshot.png         |
 | https://example.org/site/Project/1 | https://example.org/site/Dataset/2 | https://example.org/site/Image/4  | 2024-10-10_15-28-16_screenshot.png         |
 
-* Image with owner
+** Image with owner
 :PROPERTIES:
 :ID:       c856598c-c952-4964-b4b2-40b4a1269afc
 :END:
-#+begin_src sparql :url http://localhost:8080/sparql
+#+begin_src sparql
   PREFIX : <https://www.openmicroscopy.org/omemap/>
   PREFIX owl: <http://www.w3.org/2002/07/owl#>
   PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -277,24 +281,19 @@
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
   PREFIX omemap: <https://www.openmicroscopy.org/omemap#>
   prefix vcard: <https://www.w3.org/2006/vcard/ns#>
-  prefix ome_core: <http://www.openmicroscopy.org/rdf/2016-06/ome_core/>
+  PREFIX ome_core: <https://ld.openmicroscopy.org/core/>
   SELECT distinct ?img ?roi WHERE {
-      ?img a ome_core:Image;
-          ^ome_core:image ?roi .
-      ?roi a ome_core:RegionOfInterest .
+      ?img a ome_core:Image.
+          # ^ome_core:image ?roi .
+      # ?roi a ome_core:RegionOfInterest .
   }
   #+end_src
 
 #+RESULTS:
-| img                               | roi                                         |
-|-----------------------------------+---------------------------------------------|
-| https://example.org/site/Image/5  | https://example.org/site/RegionOfInterest/1 |
-| https://example.org/site/Image/6  | https://example.org/site/RegionOfInterest/2 |
-| https://example.org/site/Image/11 | https://example.org/site/RegionOfInterest/3 |
-| https://example.org/site/Image/22 | https://example.org/site/RegionOfInterest/4 |
-| https://example.org/site/Image/23 | https://example.org/site/RegionOfInterest/5 |
+| img | roi |
+|-----+-----|
 
-* Image with owner
+** Image with owner
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
@@ -319,7 +318,7 @@
 | ds | owner |
 |----+-------|
 
-* Dataset number of type relations
+** Dataset number of type relations
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
@@ -347,7 +346,7 @@
 |---------|
 |       1 |
 
-* Dataset type relations
+** Dataset type relations
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
@@ -378,7 +377,7 @@
 | https://example.org/site/Dataset/2 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/Dataset |
 | https://example.org/site/Dataset/3 | http://www.openmicroscopy.org/rdf/2016-06/ome_core/Dataset |
 
-* Image properties
+** Image properties
 :PROPERTIES:
 :ID:       7452daa7-4c93-448f-9c35-6a9efd910cb1
 :END:
@@ -410,7 +409,7 @@
 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type |
 | http://www.w3.org/2000/01/rdf-schema#label      |
 
-* Number of projects, datasets, images
+** Number of projects, datasets, images
 :PROPERTIES:
 :ID:       b8d9a7e6-cb6f-46a3-a198-f8a57a3e81ba
 :END:
@@ -441,7 +440,7 @@
 |------------+------------+----------|
 |          1 |          3 |       10 |
 
-* Project and contained datasets
+** Project and contained datasets
 :PROPERTIES:
 :ID:       9114c7b4-6367-43f6-a8d2-9583999e554f
 :END:
@@ -472,7 +471,7 @@ limit 20
 | https://example.org/site/Project/1 | Project | https://example.org/site/Dataset/3 |
 | https://example.org/site/Project/1 | Project | https://example.org/site/Dataset/2 |
 
-* Project with datasets and images
+** Project with datasets and images
 :PROPERTIES:
 :ID:       9114c7b4-6367-43f6-a8d2-9583999e554f
 :END:
@@ -514,7 +513,7 @@ limit 20
 | https://example.org/site/Project/1 | https://example.org/site/Dataset/3 | https://example.org/site/Image/8  | 2024-10-10_16-47-01_screenshot.png |
 | https://example.org/site/Project/1 | https://example.org/site/Dataset/3 | https://example.org/site/Image/9  | 2024-10-10_16-42-47_screenshot.png |
 
-* Dataset subject as per map annotation, queried by namespace:key concatenation (dc:subject)
+** Dataset subject as per map annotation, queried by namespace:key concatenation (dc:subject)
 :PROPERTIES:
 :ID:       39bce638-19c5-4ed5-9428-7bfdbdc64b72
 :END:
@@ -545,7 +544,7 @@ limit 20
 | https://example.org/site/Dataset/2 | Test images   |
 | https://example.org/site/Dataset/3 | OMERO Mapping |
 
-* Tagged images
+** Tagged images
 :PROPERTIES:
 :ID:       3fb29f13-6b99-4d93-9757-7b6d90a40e93
 :END:
@@ -575,8 +574,7 @@ limit 20
 | https://example.org/site/Image/8  | Screenshot |
 | https://example.org/site/Image/9  | Screenshot |
 
-
-* Tagged dataset
+** Tagged dataset
 :PROPERTIES:
 :ID:       5ccad4e1-5090-438e-b90c-ede0bd3356bc
 :END:
@@ -601,7 +599,7 @@ Find all datasets tagged "TestTag".
 |------------------------------------+-----------|
 | https://example.org/site/Dataset/1 | Dataset 1 |
 
-* Number of contained images per dataset (by aggregation)
+** Number of contained images per dataset (by aggregation)
 :PROPERTIES:
 :ID:       5ccad4e1-5090-438e-b90c-ede0bd3356bc
 :END:
@@ -626,7 +624,7 @@ Find all datasets tagged "TestTag".
 | https://example.org/site/Dataset/2 |                5 |
 | https://example.org/site/Dataset/1 |                2 |
 
-* Folder 
+** Folder 
 :PROPERTIES:
 :ID:       c97f7deb-8163-4c3d-9c8f-ed50b3e36552
 :END:
@@ -644,12 +642,11 @@ Find all datasets tagged "TestTag".
 | s |
 |---|
 
-
-* MPIEB
+** MPIEB
 :PROPERTIES:
 :ID:       1bdfaf0a-1483-44e0-b216-f97a319293b5
 :END:
-** SPO
+*** SPO
 :PROPERTIES:
 :ID:       b11378ed-b938-4bb9-ad4b-b9cd0df59f75
 :END:
@@ -672,7 +669,7 @@ Find all datasets tagged "TestTag".
 | https://example.org/site/Dataset/2 |                7 |
 | https://example.org/site/Dataset/1 |                2 |
 
-* Namespace fixed
+** Namespace fixed
 :PROPERTIES:
 :ID:       f538ab93-67f7-4a3e-aa6e-9b6d82e2f99c
 :END:
@@ -692,8 +689,7 @@ Find all datasets tagged "TestTag".
 |--------|
 | screen |
 
-
-* Image 9 MouseCT/Skyscan/System namespace
+** Image 9 MouseCT/Skyscan/System namespace
 :PROPERTIES:
 :ID:       d2ec4a2a-806a-45ae-95a0-3b36d16aa030
 :END:
@@ -719,8 +715,7 @@ Find all datasets tagged "TestTag".
 | http://purl.org/dc/terms/date                                         | Sat Dec 21 06:08:37 PM CET 2024                          |
 | http://MouseCT/Skyscan/System/Assay                                   | Bruker                                                   |
 
-
-* Image and Experimenter
+** Image and Experimenter
 :PROPERTIES:
 :ID:       b6fdc8c2-cadf-4241-a9d0-28f49b6efd1c
 :END:
@@ -735,7 +730,7 @@ Find all datasets tagged "TestTag".
     ?owner foaf:lastName ?last .
 #+end_src
 
-* Pixels and channels.
+** Pixels and channels.
 :PROPERTIES:
 :ID:       b6fdc8c2-cadf-4241-a9d0-28f49b6efd1c
 :END:
@@ -751,7 +746,7 @@ Find all datasets tagged "TestTag".
   limit 10
 #+end_src
 
-** Pixels
+*** Pixels
 :PROPERTIES:
 :ID:       f163b456-8c98-424b-9e8b-8d302642d707
 :END:
@@ -763,7 +758,7 @@ Find all datasets tagged "TestTag".
 | https://ld.openmicroscopy.org/omekg#physical_size_x      | 0.7400001049041748 |
 | https://ld.openmicroscopy.org/omekg#physical_size_x_unit | µm                 |
 
-** Channels
+*** Channels
 :PROPERTIES:
 :ID:       365db89d-2153-4920-b49c-ed349dca9e29
 :END:
@@ -908,7 +903,7 @@ Find all datasets tagged "TestTag".
 | https://example.org/site/Pixels/330 |       0 |         0 |        0 |     255 |         0 |      255 |
 | https://example.org/site/Pixels/331 |       0 |         0 |        0 |     255 |         0 |      255 |
 
-* Owners and Groups
+** Owners and Groups
 :PROPERTIES:
 :ID:       83f91f9d-a78e-44a0-ae4c-f24046beaa26
 :END:
@@ -945,7 +940,7 @@ Find all datasets tagged "TestTag".
  | group | name |
  |-------+------|
 
-* Federated query against ome and taxonomy database with HCS objects
+** Federated query against ome and taxonomy database with HCS objects
 :PROPERTIES:
 :ID:       94881a24-726a-40ee-b931-d46a8e31a2f1
 :END:
@@ -1093,7 +1088,7 @@ Find all datasets tagged "TestTag".
 | HUMAN    | http://purl.uniprot.org/taxonomy/11020   | Barmah forest virus                                                                           |
 | HUMAN    | http://purl.uniprot.org/taxonomy/37119   | Human papillomavirus 66                                                                       |
 
-* Federated query against locally running qlever and uniprot
+** Federated query against locally running qlever and uniprot
 :PROPERTIES:
 :ID:       deea35fd-873a-4a43-983e-6497a8a04163
 :END:

--- a/queries/sparql/queries.org
+++ b/queries/sparql/queries.org
@@ -356,95 +356,182 @@
       #+end_src
 
 #+RESULTS:
-| img                         | prop                                                     | val                                        |
-|-----------------------------+----------------------------------------------------------+--------------------------------------------|
-| http://micropop046/Image/51 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/52 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/53 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/54 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/55 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/56 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/57 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/58 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/59 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/60 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/61 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/62 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
-| http://micropop046/Image/51 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/52 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/53 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/54 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/55 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/56 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/57 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/58 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/59 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/60 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/61 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/62 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
-| http://micropop046/Image/51 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/52 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/53 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/54 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/55 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/56 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/57 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/58 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/59 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/60 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/61 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/62 | https://ld.openmicroscopy.org/core/experimenter          | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/51 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/52 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/53 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/54 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/55 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/56 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/57 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/58 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/59 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/60 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/61 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/62 | https://ld.openmicroscopy.org/omekg#experimenter         | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/51 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/52 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/53 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/54 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/55 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/56 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/57 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/58 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/59 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/60 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/61 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/62 | https://ld.openmicroscopy.org/omekg#owner                | http://micropop046/Experimenter/2          |
-| http://micropop046/Image/61 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
-| http://micropop046/Image/62 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
-| http://micropop046/Image/51 | http://purl.org/dc/elements/1.1/identifier               | 51                                         |
-| http://micropop046/Image/52 | http://purl.org/dc/elements/1.1/identifier               | 52                                         |
-| http://micropop046/Image/53 | http://purl.org/dc/elements/1.1/identifier               | 53                                         |
-| http://micropop046/Image/54 | http://purl.org/dc/elements/1.1/identifier               | 54                                         |
-| http://micropop046/Image/55 | http://purl.org/dc/elements/1.1/identifier               | 55                                         |
-| http://micropop046/Image/56 | http://purl.org/dc/elements/1.1/identifier               | 56                                         |
-| http://micropop046/Image/57 | http://purl.org/dc/elements/1.1/identifier               | 57                                         |
-| http://micropop046/Image/58 | http://purl.org/dc/elements/1.1/identifier               | 58                                         |
-| http://micropop046/Image/59 | http://purl.org/dc/elements/1.1/identifier               | 59                                         |
-| http://micropop046/Image/60 | http://purl.org/dc/elements/1.1/identifier               | 60                                         |
-| http://micropop046/Image/61 | http://purl.org/dc/elements/1.1/identifier               | 61                                         |
-| http://micropop046/Image/62 | http://purl.org/dc/elements/1.1/identifier               | 62                                         |
-| http://micropop046/Image/51 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-58-36_screenshot.png         |
-| http://micropop046/Image/52 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-53-28_screenshot.png         |
-| http://micropop046/Image/53 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-01-36_screenshot.png         |
-| http://micropop046/Image/54 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-09-28_screenshot.png         |
-| http://micropop046/Image/55 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png         |
-| http://micropop046/Image/56 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-07-18_screenshot.png         |
-| http://micropop046/Image/57 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-17-25_screenshot.png         |
-| http://micropop046/Image/58 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-39-27_screenshot.png         |
-| http://micropop046/Image/59 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-47-01_screenshot.png         |
-| http://micropop046/Image/60 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-42-47_screenshot.png         |
-| http://micropop046/Image/61 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png.ome.tif |
-| http://micropop046/Image/62 | http://www.w3.org/2000/01/rdf-schema#label               | image_6_with_roi.ome.tif                   |
+| img                               | prop                                                     | val                                        |
+|-----------------------------------+----------------------------------------------------------+--------------------------------------------|
+| https://example.org/site/Image/13 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/14 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/15 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/16 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/17 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/18 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/19 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/20 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/21 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/22 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/23 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/24 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/core/Image   |
+| https://example.org/site/Image/13 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/14 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/15 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/16 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/17 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/18 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/19 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/20 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/21 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/22 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/23 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/24 | http://www.w3.org/1999/02/22-rdf-syntax-ns#type          | https://ld.openmicroscopy.org/omekg/Image  |
+| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/core/experimenter          | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/omekg#experimenter         | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/omekg#owner                | https://example.org/site/Experimenter/2    |
+| https://example.org/site/Image/13 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:57:45 PM CEST 2025           |
+| https://example.org/site/Image/14 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:57:55 PM CEST 2025           |
+| https://example.org/site/Image/15 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:05 PM CEST 2025           |
+| https://example.org/site/Image/16 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:15 PM CEST 2025           |
+| https://example.org/site/Image/17 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:26 PM CEST 2025           |
+| https://example.org/site/Image/18 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:36 PM CEST 2025           |
+| https://example.org/site/Image/19 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:46 PM CEST 2025           |
+| https://example.org/site/Image/20 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:58:56 PM CEST 2025           |
+| https://example.org/site/Image/21 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:06 PM CEST 2025           |
+| https://example.org/site/Image/22 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:17 PM CEST 2025           |
+| https://example.org/site/Image/23 | http://purl.org/dc/terms/date                            | Mon Jun  2 03:59:28 PM CEST 2025           |
+| https://example.org/site/Image/23 | http://purl.org/dc/terms/date                            | Sat Nov  9 11:31:47 PM CET 2024            |
+| https://example.org/site/Image/24 | http://purl.org/dc/terms/date                            | Sat Nov  9 11:31:57 PM CET 2024            |
+| https://example.org/site/Image/13 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/14 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/15 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/16 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/17 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/18 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/19 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/20 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/21 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/22 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Public Screenshot                          |
+| https://example.org/site/Image/23 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
+| https://example.org/site/Image/24 | https://ld.openmicroscopy.org/omekg#tag_annotation_value | Screenshot                                 |
+| https://example.org/site/Image/13 | http://purl.org/dc/elements/1.1/identifier               | 13                                         |
+| https://example.org/site/Image/14 | http://purl.org/dc/elements/1.1/identifier               | 14                                         |
+| https://example.org/site/Image/15 | http://purl.org/dc/elements/1.1/identifier               | 15                                         |
+| https://example.org/site/Image/16 | http://purl.org/dc/elements/1.1/identifier               | 16                                         |
+| https://example.org/site/Image/17 | http://purl.org/dc/elements/1.1/identifier               | 17                                         |
+| https://example.org/site/Image/18 | http://purl.org/dc/elements/1.1/identifier               | 18                                         |
+| https://example.org/site/Image/19 | http://purl.org/dc/elements/1.1/identifier               | 19                                         |
+| https://example.org/site/Image/20 | http://purl.org/dc/elements/1.1/identifier               | 20                                         |
+| https://example.org/site/Image/21 | http://purl.org/dc/elements/1.1/identifier               | 21                                         |
+| https://example.org/site/Image/22 | http://purl.org/dc/elements/1.1/identifier               | 22                                         |
+| https://example.org/site/Image/23 | http://purl.org/dc/elements/1.1/identifier               | 23                                         |
+| https://example.org/site/Image/24 | http://purl.org/dc/elements/1.1/identifier               | 24                                         |
+| https://example.org/site/Image/13 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-58-36_screenshot.png         |
+| https://example.org/site/Image/14 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_14-53-28_screenshot.png         |
+| https://example.org/site/Image/15 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-01-36_screenshot.png         |
+| https://example.org/site/Image/16 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-09-28_screenshot.png         |
+| https://example.org/site/Image/17 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png         |
+| https://example.org/site/Image/18 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-07-18_screenshot.png         |
+| https://example.org/site/Image/19 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-17-25_screenshot.png         |
+| https://example.org/site/Image/20 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-39-27_screenshot.png         |
+| https://example.org/site/Image/21 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-47-01_screenshot.png         |
+| https://example.org/site/Image/22 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_16-42-47_screenshot.png         |
+| https://example.org/site/Image/23 | http://www.w3.org/2000/01/rdf-schema#label               | 2024-10-10_15-28-16_screenshot.png.ome.tif |
+| https://example.org/site/Image/24 | http://www.w3.org/2000/01/rdf-schema#label               | image_6_with_roi.ome.tif                   |
+| https://example.org/site/Image/13 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/14 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/15 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/16 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/17 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/18 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/19 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/20 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/21 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/22 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/23 | http://purl.org/dc/terms/contributor                     | Public Test User                           |
+| https://example.org/site/Image/23 | http://purl.org/dc/terms/contributor                     | Test User                                  |
+| https://example.org/site/Image/24 | http://purl.org/dc/terms/contributor                     | Test User                                  |
+| https://example.org/site/Image/13 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/14 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/15 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/16 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/17 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/18 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/19 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/20 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/21 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/22 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/23 | http://purl.org/dc/terms/subject                         | Public Unittest                            |
+| https://example.org/site/Image/23 | http://purl.org/dc/terms/subject                         | Unittest                                   |
+| https://example.org/site/Image/24 | http://purl.org/dc/terms/subject                         | Unittest                                   |
+| https://example.org/site/Image/24 | http://www.openmicroscopy.org/ns/default/annotator       | Public MrX                                 |
+| https://example.org/site/Image/21 | http://www.openmicroscopy.org/ns/default/Assay           | Bruker                                     |
+| https://example.org/site/Image/22 | http://www.openmicroscopy.org/ns/default/Assay           | PRTSC                                      |
+| https://example.org/site/Image/23 | http://www.openmicroscopy.org/ns/default/sampletype      | Public screen                              |
 
+** Image and DC metadata terms
+:PROPERTIES:
+:ID:       f9c6719d-7aad-460a-8200-def2533884dd
+:END:
+#+begin_src sparql
+  prefix ome_core: <https://ld.openmicroscopy.org/core/>
+  prefix dc: <http://purl.org/dc/terms/>
+
+  SELECT distinct ?img ?author ?subject WHERE {
+    ?img a ome_core:Image;
+         dc:contributor ?author;
+         dc:subject ?subject .
+    }
+      #+end_src
+
+#+RESULTS:
+| img                               | author           | subject         |
+|-----------------------------------+------------------+-----------------|
+| https://example.org/site/Image/13 | Public Test User | Public Unittest |
+| https://example.org/site/Image/14 | Public Test User | Public Unittest |
+| https://example.org/site/Image/15 | Public Test User | Public Unittest |
+| https://example.org/site/Image/16 | Public Test User | Public Unittest |
+| https://example.org/site/Image/17 | Public Test User | Public Unittest |
+| https://example.org/site/Image/18 | Public Test User | Public Unittest |
+| https://example.org/site/Image/19 | Public Test User | Public Unittest |
+| https://example.org/site/Image/20 | Public Test User | Public Unittest |
+| https://example.org/site/Image/21 | Public Test User | Public Unittest |
+| https://example.org/site/Image/22 | Public Test User | Public Unittest |
+| https://example.org/site/Image/23 | Public Test User | Public Unittest |
+| https://example.org/site/Image/23 | Public Test User | Unittest        |
+| https://example.org/site/Image/23 | Test User        | Public Unittest |
+| https://example.org/site/Image/23 | Test User        | Unittest        |
+| https://example.org/site/Image/24 | Test User        | Unittest        |
 
 ** Dataset number of type relations
 :PROPERTIES:

--- a/queries/sql/targets.org
+++ b/queries/sql/targets.org
@@ -1,8 +1,13 @@
-* All tables
+* SQL Target queries
+:PROPERTIES:
+:ID:       8f0ff23b-35e3-424d-8c4d-57a186d2c9fb
+:header-args:sql: :engine postgres :dbhost micropop046 :dbport 15432 :dbuser postgres :dbpassword postgres :database postgres
+:END:
+** All tables
 :PROPERTIES:
 :ID:       1833555d-5364-4fe1-aab7-d088644b0e87
 :END:
-#+begin_src  sql :engine postgres :dbhost micropop046 :dbport 15432 :dbuser postgres :dbpassword postgres :database postgres
+#+begin_src  sql :dbhost micropop046 :dbport 15432 :dbuser postgres :dbpassword postgres :database postgres
 SELECT table_name FROM information_schema.tables where table_schema='public'
 ORDER BY table_name;
 #+end_src
@@ -222,7 +227,7 @@ ORDER BY table_name;
 | wellreagentlink                                  |
 | wellsample                                       |
 
-* All in columns in roi
+** All in columns in roi
 :PROPERTIES:
 :ID:       7ba37cb7-5374-4702-a8e4-9002f4af62ef
 :END:
@@ -246,7 +251,7 @@ ORDER BY table_name;
 | image       |
 | source      |
 
-* Image and ROI
+** Image and ROI
 :PROPERTIES:
 :ID:       5c84a6e2-b418-4c21-b455-ee4a76475e60
 :END:
@@ -268,7 +273,7 @@ ORDER BY table_name;
 |        9 |        |
 |        7 |        |
 
-* All in columns in image
+** All in columns in image
 :PROPERTIES:
 :ID:       cd51a3b2-086b-44c8-a129-284dea4d5306
 :END:
@@ -301,7 +306,7 @@ ORDER BY table_name;
 | objectivesettings  |
 | stagelabel         |
 
-* Projects
+** Projects
 :PROPERTIES:
 :ID:       466e7663-27d9-48e6-b10c-4bcaa238d145
 :END:
@@ -314,12 +319,32 @@ ORDER BY table_name;
 |----+-------------+-------------+-----------+---------+-------------+-------------+----------+----------+-----------+----+-------------+---------+-------+-------------+-------------+----------+----------+-----------+--------|
 | 51 |             |          -8 | TFLM      |         |        5865 |             |       53 |       52 |      5865 |    |             |         |       |             |             |          |          |           |        |
 |  1 |             |         -40 | project01 |         |        1162 |             |        3 |        2 |      1162 |    |             |         |       |             |             |          |          |           |        |
+** Dataset
+:PROPERTIES:
+:ID:       c48e7dd2-6a61-41ea-b7c7-7816efd7d2cf
+:END:
+#+begin_src  sql :engine postgres :dbhost micropop046 :dbport 15432 :dbuser ontop :dbpassword '!ontop$' :database postgres
+select
+          		_dataset.id as dataset_id,
+			_dataset.name as dataset_name,
+			_dataset.description as dataset_description
+			from dataset as _dataset
+      where _dataset.owner_id=2
 
-* Image
+#+end_src
+
+#+RESULTS:
+| dataset_id | dataset_name | dataset_description |
+|------------+--------------+---------------------|
+|          4 | Dataset 1    |                     |
+|          5 | Dataset 2    |                     |
+|          6 | Dataset 3    |                     |
+
+** Image
 :PROPERTIES:
 :ID:       71a91350-a2a8-4479-bfad-19325d02fd25
 :END:
-** All attributes
+*** All attributes
 :PROPERTIES:
 :ID:       7425289d-e78a-4b06-81eb-855f28abde0a
 :END:
@@ -343,7 +368,7 @@ ORDER BY table_name;
 | 11 |                 |          |             |        -120 | 2024-10-10_15-28-16_screenshot.png.ome.tif |         |      0 |         |         591 |             |        0 |        0 |       591 |            |      11 |    170 |                  1 |            |                   |            |
 | 12 |                 |          |             |        -120 | image_6_with_roi.ome.tif                   |         |      0 |         |         619 |             |        0 |        0 |       619 |            |      12 |    170 |                  2 |            |                   |            |
 
-** Image annotations
+*** Image annotations
 :PROPERTIES:
 :ID:       9b14e702-bc4d-4e75-8ff1-5236c6fa3a2b
 :END:
@@ -358,7 +383,7 @@ ORDER BY table_name;
 #+RESULTS:
 |---|
 
-* Folder
+** Folder
 :PROPERTIES:
 :ID:       62965f07-a737-4050-b2ee-6418baff21f3
 :END:
@@ -370,7 +395,7 @@ ORDER BY table_name;
 | id | description | permissions | name | version | creation_id | external_id | group_id | owner_id | update_id | parentfolder |
 |----+-------------+-------------+------+---------+-------------+-------------+----------+----------+-----------+--------------|
 
-* Folderannotationlink
+** Folderannotationlink
 :PROPERTIES:
 :ID:       12bc20b2-9037-4f1b-9612-0fa8c36aaabc
 :END:
@@ -382,7 +407,7 @@ ORDER BY table_name;
 | id | permissions | version | child | creation_id | external_id | group_id | owner_id | update_id | parent |
 |----+-------------+---------+-------+-------------+-------------+----------+----------+-----------+--------|
 
-* datasets in separate joins
+** datasets in separate joins
 :PROPERTIES:
 :ID:       c254b55f-6517-4782-a09a-f38c937e5231
 :END:
@@ -401,7 +426,7 @@ ORDER BY table_name;
 #+RESULTS:
 |---|
 
-* Annotations
+** Annotations
 :PROPERTIES:
 :ID:       c163c7b2-d0be-4894-bfb4-ebce24817c0e
 :END:
@@ -434,7 +459,7 @@ ORDER BY table_name;
       | /map/            | 18 |             |        -120 |      | http://purl.org/dc/terms/ |       3 |           |            |             |           |           |           |         679 |             |        0 |        0 |       683 |      |
       | /map/            | 19 |             |        -120 |      | http://purl.org/dc/terms/ |       3 |           |            |             |           |           |           |         685 |             |        0 |        0 |       689 |      |
 
-* namespace string check and set
+** namespace string check and set
 :PROPERTIES:
 :ID:       ed9d6bf8-7e22-4e3d-b168-f0002e86ac59
 :END:
@@ -485,7 +510,7 @@ ORDER BY table_name;
 | http://purl.org/dc/terms/                                  | http://purl.org/dc/terms/                           |
 | http://purl.org/dc/terms/                                  | http://purl.org/dc/terms/                           |
 
-* namespace regex replace
+** namespace regex replace
 :PROPERTIES:
 :ID:       ed9d6bf8-7e22-4e3d-b168-f0002e86ac59
 :END:
@@ -535,12 +560,11 @@ ORDER BY table_name;
 | http://purl.org/dc/terms/                 | http://purl.org/dc/terms/                           |
 | http://purl.org/dc/terms/                 | http://purl.org/dc/terms/                           |
 
-
-* Experimenter and ExperimenterGroups
+** Experimenter and ExperimenterGroups
 :PROPERTIES:
 :ID:       1ee4a685-bff6-4acd-ad06-c96b32be98b5
 :END:
-** Experimenter
+*** Experimenter
 :PROPERTIES:
 :ID:       e0f747e1-c4e7-4a35-b207-1147ce930b8b
 :END:
@@ -555,7 +579,7 @@ ORDER BY table_name;
 |  0 |           0 |       | root      |             | root     | f    |            | root    |       0 |             |
 |  1 |           0 |       | Guest     |             | Account  | f    |            | guest   |       0 |             |
 
-** Experiment
+*** Experiment
 :PROPERTIES:
 :ID:       104cf1b6-2322-410e-8089-f53fb6140138
 :END:
@@ -568,7 +592,7 @@ ORDER BY table_name;
 | id | description | permissions | version | creation_id | external_id | group_id | owner_id | update_id | type |
 |----+-------------+-------------+---------+-------------+-------------+----------+----------+-----------+------|
 
-** ExperimenterGrous
+*** ExperimenterGrous
 :PROPERTIES:
 :ID:       104cf1b6-2322-410e-8089-f53fb6140138
 :END:
@@ -584,11 +608,11 @@ ORDER BY table_name;
 |  1 |             |         -52 | f    | user   |       0 |             |
 |  2 |             |        -120 | f    | guest  |       0 |             |
 
-* HCS
+** HCS
 :PROPERTIES:
 :ID:       dadc3b79-19e0-4b22-bd66-d981870fe444
 :END:
-** Screens
+*** Screens
 :PROPERTIES:
 :ID:       df1a9716-ab75-4b52-8d72-8f1d513dd2f4
 :END:
@@ -702,7 +726,7 @@ ORDER BY table_name;
 |  99 |        -120 | reference frame | -757.759765625 | reference frame |    757.759765625 |           |         |       11414 |             |        0 |        0 |     11414 |   343 |                1 |   25 |          2 |
 | 100 |        -120 | reference frame |  757.759765625 | reference frame |    757.759765625 |           |         |       11414 |             |        0 |        0 |     11414 |   344 |                1 |   25 |          3 |
 
-* Channel
+** Channel
 :PROPERTIES:
 :ID:       f24c3f74-96ea-426d-9fac-29a94d1e92be
 :END:
@@ -745,7 +769,7 @@ ORDER BY table_name;
 | 753 |        -120 |             | µm                | 0.7400001049041748 | µm                | 0.7400001049041748 |                   |               | 6eea4b837163791320e53838e375a1a1dcbc7f1c |              16 |     2 |     1 |  2048 |  2048 |     1 |                   |               |         |               |           |       11414 |             |        0 |        0 |     14604 |              1 |   753 |          6 |           |           0 | root_0/2025-02/13/11-28-21.117 | 2011-11-17 X-Man LOPAC_X03_LP_S01_1.xdce   | 34a716b6-d4f9-4cea-861b-4229819e82d8 |
 | 754 |        -120 |             | µm                | 0.7400001049041748 | µm                | 0.7400001049041748 |                   |               | 6eea4b837163791320e53838e375a1a1dcbc7f1c |              16 |     2 |     1 |  2048 |  2048 |     1 |                   |               |         |               |           |       11414 |             |        0 |        0 |     14604 |              1 |   754 |          6 |           |           0 | root_0/2025-02/13/11-28-21.117 | 2011-11-17 X-Man LOPAC_X03_LP_S01_1.xdce   | 34a716b6-d4f9-4cea-861b-4229819e82d8 |
 | 755 |        -120 |             | µm                | 0.7400001049041748 | µm                | 0.7400001049041748 |                   |               | 6eea4b837163791320e53838e375a1a1dcbc7f1c |              16 |     2 |     1 |  2048 |  2048 |     1 |                   |               |         |               |           |       11414 |             |        0 |        0 |     14604 |              1 |   755 |          6 |           |           0 | root_0/2025-02/13/11-28-21.117 | 2011-11-17 X-Man LOPAC_X03_LP_S01_1.xdce   | 34a716b6-d4f9-4cea-861b-4229819e82d8 |
-* PixelsDimensionsOrder
+** PixelsDimensionsOrder
 :PROPERTIES:
 :ID:       c896882f-d257-4234-8191-1c7a84ad780d
 :END:
@@ -760,7 +784,7 @@ ORDER BY table_name;
 event                                            
 eventlog                                        
 eventtype                                      |
-* Events
+** Events
 :PROPERTIES:
 :ID:       f534f360-c0b3-4da3-a19b-9cbe6ef6f343
 :END:

--- a/queries/sql/targets.org
+++ b/queries/sql/targets.org
@@ -7,7 +7,7 @@
 :PROPERTIES:
 :ID:       1833555d-5364-4fe1-aab7-d088644b0e87
 :END:
-#+begin_src  sql :dbhost micropop046 :dbport 15432 :dbuser postgres :dbpassword postgres :database postgres
+#+begin_src  sql :dbuser postgres :dbpassword postgres :database postgres
 SELECT table_name FROM information_schema.tables where table_schema='public'
 ORDER BY table_name;
 #+end_src
@@ -348,25 +348,25 @@ select
 :PROPERTIES:
 :ID:       7425289d-e78a-4b06-81eb-855f28abde0a
 :END:
-#+begin_src  sql :engine postgres :dbhost localhost :dbport 15432 :dbuser postgres :dbpassword postgres :database postgres
-  select * from image; limit 10
+#+begin_src  sql
+  select owner_id from image where owner_id=2
 #+end_src
 
 #+RESULTS:
-| id | acquisitiondate | archived | description | permissions | name                                       | partial | series | version | creation_id | external_id | group_id | owner_id | update_id | experiment | fileset | format | imagingenvironment | instrument | objectivesettings | stagelabel |
-|----+-----------------+----------+-------------+-------------+--------------------------------------------+---------+--------+---------+-------------+-------------+----------+----------+-----------+------------+---------+--------+--------------------+------------+-------------------+------------|
-|  1 |                 |          |             |        -120 | 2024-10-10_14-58-36_screenshot.png         |         |      0 |         |         311 |             |        0 |        0 |       311 |            |       1 |      4 |                    |            |                   |            |
-|  2 |                 |          |             |        -120 | 2024-10-10_14-53-28_screenshot.png         |         |      0 |         |         339 |             |        0 |        0 |       339 |            |       2 |      4 |                    |            |                   |            |
-|  3 |                 |          |             |        -120 | 2024-10-10_15-17-25_screenshot.png         |         |      0 |         |         367 |             |        0 |        0 |       367 |            |       3 |      4 |                    |            |                   |            |
-|  4 |                 |          |             |        -120 | 2024-10-10_15-28-16_screenshot.png         |         |      0 |         |         395 |             |        0 |        0 |       395 |            |       4 |      4 |                    |            |                   |            |
-|  5 |                 |          |             |        -120 | 2024-10-10_15-01-36_screenshot.png         |         |      0 |         |         423 |             |        0 |        0 |       423 |            |       5 |      4 |                    |            |                   |            |
-|  6 |                 |          |             |        -120 | 2024-10-10_15-09-28_screenshot.png         |         |      0 |         |         451 |             |        0 |        0 |       451 |            |       6 |      4 |                    |            |                   |            |
-|  7 |                 |          |             |        -120 | 2024-10-10_15-07-18_screenshot.png         |         |      0 |         |         479 |             |        0 |        0 |       479 |            |       7 |      4 |                    |            |                   |            |
-|  8 |                 |          |             |        -120 | 2024-10-10_16-47-01_screenshot.png         |         |      0 |         |         507 |             |        0 |        0 |       507 |            |       8 |      4 |                    |            |                   |            |
-|  9 |                 |          |             |        -120 | 2024-10-10_16-42-47_screenshot.png         |         |      0 |         |         535 |             |        0 |        0 |       535 |            |       9 |      4 |                    |            |                   |            |
-| 10 |                 |          |             |        -120 | 2024-10-10_16-39-27_screenshot.png         |         |      0 |         |         563 |             |        0 |        0 |       563 |            |      10 |      4 |                    |            |                   |            |
-| 11 |                 |          |             |        -120 | 2024-10-10_15-28-16_screenshot.png.ome.tif |         |      0 |         |         591 |             |        0 |        0 |       591 |            |      11 |    170 |                  1 |            |                   |            |
-| 12 |                 |          |             |        -120 | image_6_with_roi.ome.tif                   |         |      0 |         |         619 |             |        0 |        0 |       619 |            |      12 |    170 |                  2 |            |                   |            |
+| owner_id |
+|----------|
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
+|        2 |
 
 *** Image annotations
 :PROPERTIES:

--- a/queries/sql/targets.org
+++ b/queries/sql/targets.org
@@ -805,3 +805,8 @@ eventtype                                      |
 |  7 |         -52 | Processing |             |
 |  8 |         -52 | FullText   |             |
 |  9 |         -52 | Sessions   |             |
+
+** Reagents
+:PROPERTIES:
+:ID:       6658058e-8998-42a5-8f7a-78d0ffc5e43b
+:END:

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -965,5 +965,23 @@ SELECT DISTINCT * WHERE {
         self.assertEqual(results['min_red'].sum(), 0)
         self.assertTrue(all(results['max_blue'] == 255))
 
+
+    def test_public_private(self):
+        """ Test we cannot access a non-public image"""
+
+
+        query_string = f"""
+    prefix omekg: <https://ld.openmicroscopy.org/omekg/>
+    prefix exoimg: <https://example.org/Image/>
+    select * where {{
+        exoimg:1 ?prop ?val .
+        }}
+        """
+
+        results = run_query(query_string)
+
+        self.assertEqual(len(results), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -982,6 +982,5 @@ SELECT DISTINCT * WHERE {
 
         self.assertEqual(len(results), 0)
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -10,7 +10,6 @@ from urllib import parse
 import unittest
 
 ENDPOINT = "http://localhost:8080/sparql"
-ENDPOINT = "http://micropop046:8080/sparql"
 
 # Check if endpoint is reachable.
 def check_endpoint():
@@ -374,7 +373,7 @@ select ?n_projects ?n_datasets ?n_images where {{
         response = graph.query(query_string)
 
         # Test.
-        self.assertEqual(len(response), 1548)
+        self.assertEqual(len(response), 12)
 
     def test_project_dataset_image(self):
         """ Test a query for a project-dataset-image hierarchy. """

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -162,7 +162,7 @@ select ?n_projects ?n_datasets ?n_images where {{
 
         # Check numbers.
         number_of_objects = [r for r in response][0]
-        self.assertEqual(int(number_of_objects.n_images  ),  1548)
+        self.assertEqual(int(number_of_objects.n_images  ),  12)
         self.assertEqual(int(number_of_objects.n_datasets), 3)
         self.assertEqual(int(number_of_objects.n_projects), 1)
 
@@ -306,11 +306,9 @@ select ?n_projects ?n_datasets ?n_images where {{
         # Run the query.
         response = run_query(query_string).set_index('owner_id')
 
-        print("\n" + response.to_string())
-
-        self.assertEqual(response.loc['0', 'name'], 'Guest Account')
-        self.assertEqual(response.loc['0', 'name'], 'Guest Account')
-        self.assertEqual(response.loc['1', 'name'], 'root root')
+        self.assertEqual(response.loc['0', 'name'], 'root root')
+        self.assertEqual(response.loc['1', 'name'], 'Guest Account')
+        self.assertEqual(response.loc['2', 'name'], 'Public User')
 
     def test_dataset_core(self):
         """ Test query with the core prefix and ontology. """
@@ -419,7 +417,7 @@ select ?n_projects ?n_datasets ?n_images where {{
         # Run the query.
         response = graph.query(query_string)
 
-        self.assertEqual(len(response), 12)
+        self.assertEqual(len(response), 15)
 
     def test_project_key_value(self):
         """ Test querying for a project property via the mapannotation key."""
@@ -428,14 +426,13 @@ select ?n_projects ?n_datasets ?n_images where {{
 
         query_string = f"""
         prefix ome_core: <https://ld.openmicroscopy.org/core/>
-        prefix dc: <http://purl.org/dc/terms/>
+        prefix dcterms: <http://purl.org/dc/terms/>
 
-        SELECT distinct ?project ?author ?subject ?provenance WHERE {{
+        SELECT distinct ?project ?author ?subject WHERE {{
           SERVICE <{ENDPOINT}> {{
             ?project a ome_core:Project;
-                 dc:contributor ?author;
-                 dc:subject ?subject;
-                 dc:provenance ?provenance.
+                 dcterms:contributor ?author;
+                 dcterms:subject ?subject;
          }}
         }}
         """
@@ -481,7 +478,7 @@ select ?n_projects ?n_datasets ?n_images where {{
 
         response = run_query(query)
         self.assertEqual(len(response), 1)
-        self.assertEqual(response.loc[0, 'tag'], 'TestTag')
+        self.assertEqual(response.loc[0, 'tag'], 'Public TestTag')
 
     def test_tagged_images(self):
         """ Test querying all tagged images and their tag(s). """
@@ -499,10 +496,10 @@ select ?n_projects ?n_datasets ?n_images where {{
         response = run_query(query)
 
         # All images (10) are tagged.
-        self.assertEqual(len(response), 12)
+        self.assertEqual(len(response), 13)
 
         # They're all tagged "Screenshot"
-        self.assertEqual(response.loc[0, 'tag'], "Screenshot")
+        self.assertEqual(response.loc[0, 'tag'], "Public Screenshot")
 
     def test_image_roi(self):
         """ Test querying image with ROI. """
@@ -559,12 +556,12 @@ PREFIX image: <https://example.org/site/Image/>
 PREFIX ome_ns: <http://www.openmicroscopy.org/ns/default/>
 
 SELECT DISTINCT * WHERE {
-  image:11 ome_ns:sampletype ?st .
+  image:23 ome_ns:sampletype ?st .
 }
 """
         response_df = run_query(query)
 
-        self.assertEqual(response_df.iloc[0,0], 'screen')
+        self.assertEqual(response_df.iloc[0,0], 'Public screen')
 
     def test_namespace_fixing_no_ns(self):
         """ Test that empty namespaces are set to a default value."""
@@ -574,12 +571,12 @@ PREFIX image: <https://example.org/site/Image/>
 PREFIX ome_ns: <http://www.openmicroscopy.org/ns/default/>
 
 SELECT DISTINCT * WHERE {
-  image:12 ome_ns:annotator ?st .
+  image:24 ome_ns:annotator ?st .
 }
 """
         response_df = run_query(query)
 
-        self.assertEqual(response_df.iloc[0,0], 'MrX')
+        self.assertEqual(response_df.iloc[0,0], 'Public MrX')
 
     def test_namespace_fixing_issue16(self):
         """ Test that empty namespaces are set to a default value."""
@@ -589,10 +586,12 @@ PREFIX image: <https://example.org/site/Image/>
 PREFIX ome_ns: <http://www.openmicroscopy.org/ns/default/>
 
 SELECT DISTINCT * WHERE {
-  image:10 ome_ns:Assay ?assay .
+  image:22 ome_ns:Assay ?assay .
 }
 """
         response_df = run_query(query)
+
+        print(response_df.to_string())
 
         self.assertEqual(response_df.iloc[0,0], 'PRTSC')
 
@@ -604,7 +603,7 @@ PREFIX image: <https://example.org/site/Image/>
 PREFIX ome_ns: <http://www.openmicroscopy.org/ns/default/>
 
 SELECT DISTINCT * WHERE {
-  image:9 ome_ns:Assay ?assay .
+  image:21 ome_ns:Assay ?assay .
 }
 """
         response_df = run_query(query)
@@ -637,6 +636,7 @@ SELECT DISTINCT * WHERE {
         print("\n"+response.to_string())
 
 
+    @unittest.expectedFailure
     def test_screen(self):
         """ Test query for a screen."""
 
@@ -655,7 +655,8 @@ SELECT DISTINCT * WHERE {
         print("\n"+results.to_string())
 
         self.assertEqual(1, len(results))
-    
+
+    @unittest.expectedFailure
     def test_plate(self):
         """ Test query for a plate."""
 
@@ -675,6 +676,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertEqual(1, len(results))
 
+    @unittest.expectedFailure
     def test_screen_plate(self):
         """ Test query for screen and related plate."""
         results = run_query("""
@@ -693,6 +695,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertTupleEqual((1, 2), results.shape)
 
+    @unittest.expectedFailure
     def test_plate_acquisition(self):
         """ Test query for plate and plate acquisition."""
 
@@ -712,6 +715,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertTupleEqual( (1,2), results.shape )
 
+    @unittest.expectedFailure
     def test_plate_well(self):
         """ Test query for plate-acquisition and well. """
 
@@ -731,6 +735,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertTupleEqual((384, 2), results.shape)
 
+    @unittest.expectedFailure
     def test_well_sample(self):
         """ Test query for well and well sample."""
 
@@ -752,6 +757,7 @@ SELECT DISTINCT * WHERE {
         self.assertTupleEqual((384*4, 2), results.shape)
 
 
+    @unittest.expectedFailure
     def test_well_sample_image(self):
         """ Test query for  well sample and image. """
 
@@ -771,6 +777,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertTupleEqual((1536, 2), results.shape)
 
+    @unittest.expectedFailure
     def test_plateAcquisition(self):
         """ Test query for a PlateAcquisition."""
 
@@ -790,7 +797,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertEqual(1, len(results))
 
-    def test_reagent(self):
+    def test_reagent_1(self):
         """ Test query for a reagent."""
 
         query = """
@@ -809,6 +816,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertEqual(0, len(results))
 
+    @unittest.expectedFailure
     def test_plate_key_value(self):
         """ Test querying for plate kv annotations as properties and values. """
 
@@ -836,6 +844,7 @@ SELECT DISTINCT * WHERE {
 
         self.assertIn("CellLineMutation", results['key'].values)
 
+    @unittest.expectedFailure
     def test_well_key_value(self):
         """ Test querying for a well kv-annotations as property value pairs."""
 
@@ -867,6 +876,7 @@ SELECT DISTINCT * WHERE {
         self.assertEqual("NCBITaxon_9606", results['TermSource1Accession'])
         self.assertEqual('0.610481812', results["nseg.0.m.eccentricity.mean"])
 
+    @unittest.expectedFailure
     def test_wellsample(self):
         """ Test querying for a wellsample. """
 
@@ -888,7 +898,7 @@ SELECT DISTINCT * WHERE {
         self.assertTupleEqual((1536,1), results.shape)
 
     def test_reagents(self):
-        """ Test querying for a reagent. """
+        """ Test querying for multiple reagents. """
 
         query_string = f"""
         prefix ome_core: <https://ld.openmicroscopy.org/core/>
@@ -929,7 +939,7 @@ SELECT DISTINCT * WHERE {
 
         print('\n' + results.to_string())
 
-    def test_pixels(self):
+    def test_channels(self):
         """ Test querying for Channels object. """
 
         query_string = f"""

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -407,7 +407,7 @@ select ?n_projects ?n_datasets ?n_images where {{
         prefix ome_core: <https://ld.openmicroscopy.org/core/>
         prefix dc: <http://purl.org/dc/terms/>
 
-        SELECT distinct ?img ?author ?subject ?provenance WHERE {{
+        SELECT distinct ?img ?author ?subject WHERE {{
           SERVICE <{ENDPOINT}> {{
             ?img a ome_core:Image;
                  dc:contributor ?author;
@@ -523,10 +523,10 @@ SELECT distinct ?img ?roi WHERE {
         results = run_query(query)
 
         # Check return values.
-        self.assertEqual(results.loc[0, "img"], "https://example.org/site/Image/11")
-        self.assertEqual(results.loc[0, "roi"], "https://example.org/site/ROI/1")
-        self.assertEqual(results.loc[1, "img"], "https://example.org/site/Image/12")
-        self.assertEqual(results.loc[1, "roi"], "https://example.org/site/ROI/2")
+        self.assertEqual(results.loc[0, "img"], "https://example.org/site/Image/23")
+        self.assertEqual(results.loc[0, "roi"], "https://example.org/site/ROI/3")
+        self.assertEqual(results.loc[1, "img"], "https://example.org/site/Image/24")
+        self.assertEqual(results.loc[1, "roi"], "https://example.org/site/ROI/4")
 
     def test_image_properties(self):
         """ Check Image instances have all expected properties. """

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -10,6 +10,7 @@ from urllib import parse
 import unittest
 
 ENDPOINT = "http://localhost:8080/sparql"
+ENDPOINT = "http://micropop046:8080/sparql"
 
 # Check if endpoint is reachable.
 def check_endpoint():

--- a/utils/create_public_omero_user.sh
+++ b/utils/create_public_omero_user.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Create the public user in omero and configure omero to login as public by default
+omero login -C -u root -w omero
+omero group add --type read-only public
+omero user add -P public public Public User public
+omero config set omero.web.public.enabled True
+omero config set omero.web.public.user 'public'
+omero config set omero.web.public.password 'public'
+omero config set omero.web.public.server_id 1

--- a/utils/create_public_omero_user.sh
+++ b/utils/create_public_omero_user.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+set -e
+
 # Create the public user in omero and configure omero to login as public by default
-omero login -C -u root -w omero
+omero login -C -u root -w omero -s localhost -p 14064
 omero group add --type read-only public
 omero user add -P public public Public User public
 omero config set omero.web.public.enabled True

--- a/utils/insert_hcs.sh
+++ b/utils/insert_hcs.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
 set -e
 
-omero login -C -u root -w omero -s localhost:14064
+omero login -C -u public -w public -s micropop046:14064
 
 # Create a Screen
 Screen=$(omero obj new Screen name="IDR0017-Screen")
 
 # Import HCS dataset
-omero import img/idr0017/2011-11-17\ X-Man\ LOPAC_X03_LP_S01_1.xdce -t $Screen
+omero import img/idr0017/2011-11-17\ X-Man\ LOPAC_X03_LP_S01_1.xdce -T $Screen

--- a/utils/insert_public_data.sh
+++ b/utils/insert_public_data.sh
@@ -4,9 +4,9 @@ set -e
 omero login -C -u public -w public -s localhost:14064
 
 # Create 3 datasets
-DS1=$(omero obj new Dataset name="Dataset 1")
-DS2=$(omero obj new Dataset name="Dataset 2")
-DS3=$(omero obj new Dataset name="Dataset 3")
+DS1=$(omero obj new Dataset name="Public Dataset 1")
+DS2=$(omero obj new Dataset name="Public Dataset 2")
+DS3=$(omero obj new Dataset name="Public Dataset 3")
 # Annotations
 MAP1=$(omero obj new MapAnnotation ns=http://purl.org/dc/terms/)
 omero obj new DatasetAnnotationLink parent=$DS1 child=$MAP1
@@ -14,7 +14,7 @@ omero obj map-set $MAP1 mapValue contributor "Public User"
 omero obj map-set $MAP1 mapValue subject "Public Test images"
 omero obj map-set $MAP1 mapValue provenance "Public Screenshots"
 
-TAG1=$(omero tag create --name "TestTag")
+TAG1=$(omero tag create --name "Public TestTag")
 omero obj new DatasetAnnotationLink parent=$DS1 child=$TAG1
 # TBD: Link to DS1
 
@@ -31,7 +31,7 @@ omero obj map-set $MAP3 mapValue subject "OMERO Mapping"
 omero obj map-set $MAP3 mapValue provenance "Screenshots"
 
 # Create Project
-PROJ=$(omero obj new Project name="Project" )
+PROJ=$(omero obj new Project name="Public Project" )
 # Add to datasets to project
 omero obj new ProjectDatasetLink parent=$PROJ child=$DS1
 omero obj new ProjectDatasetLink parent=$PROJ child=$DS2
@@ -40,9 +40,9 @@ omero obj new ProjectDatasetLink parent=$PROJ child=$DS3
 # Add project annotation.
 MAP4=$(omero obj new MapAnnotation ns="http://purl.org/dc/terms/")
 omero obj new ProjectAnnotationLink parent=$PROJ child=$MAP4
-omero obj map-set $MAP4 mapValue contributor "Nophretete"
-omero obj map-set $MAP4 mapValue subject "OMERO Ontology"
-omero obj map-set $MAP4 mapValue provenance "Test Data"
+omero obj map-set $MAP4 mapValue contributor "Public Nophretete"
+omero obj map-set $MAP4 mapValue subject "Public OMERO Ontology"
+omero obj map-set $MAP4 mapValue provenance "Public Test Data"
 
 
 # Add images
@@ -58,34 +58,34 @@ for img in $images3; do omero import $img -d $DS3; done
 images4=$(find img/ -name "*.ome.tif" | xargs -i realpath {}) 
 for img in $images4; do omero import $img -d $DS2; done
 
-TAG2=$(omero tag create --name "Screenshot")
-for image_index in {1..10}; do
+TAG2=$(omero tag create --name "Public Screenshot")
+for image_index in {13..23}; do
     ann=$(omero obj new MapAnnotation ns="http://purl.org/dc/terms/")
     omero obj new ImageAnnotationLink parent=Image:$image_index child=$ann
     omero obj map-set $ann mapValue date "$(date)"
-    omero obj map-set $ann mapValue contributor "Test User"
-    omero obj map-set $ann mapValue subject "Unittest"
+    omero obj map-set $ann mapValue contributor "Public Test User"
+    omero obj map-set $ann mapValue subject "Public Unittest"
     omero obj new ImageAnnotationLink parent=Image:$image_index child=$TAG2
 done
 
 # Add another mapannotation but do not specify the namespace.
 ann=$(omero obj new MapAnnotation)
-omero obj new ImageAnnotationLink parent=Image:12 child=$ann
-omero obj map-set $ann mapValue annotator "MrX"
+omero obj new ImageAnnotationLink parent=Image:24 child=$ann
+omero obj map-set $ann mapValue annotator "Public MrX"
 
 # Add another mapannotation with namespace that is not a valid URI
 ann=$(omero obj new MapAnnotation ns="www.openmicroscopy.org/ns/default")
-omero obj new ImageAnnotationLink parent=Image:11 child=$ann
-omero obj map-set $ann mapValue sampletype "screen"
+omero obj new ImageAnnotationLink parent=Image:25 child=$ann
+omero obj map-set $ann mapValue sampletype "Public screen"
 
 # Add another mapannotation with namespace that is not a valid URI (issue #16).
 ann=$(omero obj new MapAnnotation ns="hms.harvard.edu/omero/forms/kvdata/MPB Annotations/")
-omero obj new ImageAnnotationLink parent=Image:10 child=$ann
+omero obj new ImageAnnotationLink parent=Image:22 child=$ann
 omero obj map-set $ann mapValue Assay "PRTSC"
 
 # Add another mapannotation with namespace that starts with "/" (issue #17)
 ann=$(omero obj new MapAnnotation ns="/MouseCT/Skyscan/System")
-omero obj new ImageAnnotationLink parent=Image:9 child=$ann
+omero obj new ImageAnnotationLink parent=Image:21 child=$ann
 omero obj map-set $ann mapValue Assay "Bruker"
 
 # List all objects

--- a/utils/insert_public_data.sh
+++ b/utils/insert_public_data.sh
@@ -75,7 +75,7 @@ omero obj map-set $ann mapValue annotator "Public MrX"
 
 # Add another mapannotation with namespace that is not a valid URI
 ann=$(omero obj new MapAnnotation ns="www.openmicroscopy.org/ns/default")
-omero obj new ImageAnnotationLink parent=Image:25 child=$ann
+omero obj new ImageAnnotationLink parent=Image:23 child=$ann
 omero obj map-set $ann mapValue sampletype "Public screen"
 
 # Add another mapannotation with namespace that is not a valid URI (issue #16).


### PR DESCRIPTION
This PR introduces changes in the template mappings:
- all target sql queries have an additional `if user_id=2` filter, returning only objects owned by the default public user.
- deploy script: The sql filter is given to the deploy script as a third argument and applied to the template mappings.
- test data: all 12 test data images are submitted again for the public user
- unittest: Tests are added that assert only publicly owned objects are returned by queries against the VKG. Old tests are adjusted.