### PR TITLE
Fix target mapping for image relationships

### DIFF
--- a/omero-ontop-mappings/omero-ontop-mappings.obda
+++ b/omero-ontop-mappings/omero-ontop-mappings.obda
@@ -219,7 +219,7 @@ source		select
 			join annotation on projectannotationlink.child = annotation.id where annotation.textvalue is not NULL
 
 mappingId	MAPID-dataset-image
-target		ome_instance:Dataset/{dataset_id} dcterms:hasPart ome_instance:Image/{image_id} . ome_instance:Image/{dataset_id} dcterms:isPartOf ome_instance:Dataset/{dataset_id} . 
+target		ome_instance:Dataset/{dataset_id} dcterms:hasPart ome_instance:Image/{image_id} . ome_instance:Image/{image_id} dcterms:isPartOf ome_instance:Dataset/{dataset_id} . 
 source		select
 			_dataset.id as dataset_id,
 			_datasetimagelink.child as image_id


### PR DESCRIPTION
The Image dcterms:isPartOf triple was incorrectly using the dataset ID as the image IRI. Now it is possible go "up"  Image → Dataset → Project.
`
Test query:
PREFIX core:    <https://ld.openmicroscopy.org/core/>
PREFIX dc:      <http://purl.org/dc/elements/1.1/>
PREFIX dcterms: <http://purl.org/dc/terms/>

SELECT DISTINCT ?image ?dataset ?project
WHERE {
  ### Given image ID, find project.
  VALUES ?image_id { 1055 }

  ?image a core:Image ;
         dc:identifier ?image_id ;
         dcterms:isPartOf ?dataset .

  ?dataset a core:Dataset ;
           dcterms:isPartOf ?project .

  ?project a core:Project .
  `