### PR TITLE
new insert_data script

### DIFF
--- a/.github/workflows/selfhosted-omero.yml
+++ b/.github/workflows/selfhosted-omero.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Default: keep CI fast; HCS tests are skipped by pytest.
       # Set to "1" if you want HSC test.
-      RUN_HCS_IN_CI: "1"
+      RUN_HCS_IN_CI: "0"
 
     steps:
       - uses: actions/checkout@v4

--- a/utils/insert_data_unified.sh
+++ b/utils/insert_data_unified.sh
@@ -139,8 +139,7 @@ TAG1="$(run_omero "tag create --name 'TestTag'")"
 run_omero "obj new DatasetAnnotationLink parent='$DS1' child='$TAG1'"
 
 MAP2="$(run_omero "obj new MapAnnotation ns='http://purl.org/dc/terms/'")"
-# Preserve original behavior: DS2 linked to MAP1
-run_omero "obj new DatasetAnnotationLink parent='$DS2' child='$MAP1'"
+run_omero "obj new DatasetAnnotationLink parent='$DS2' child='$MAP2'"
 run_omero "obj map-set '$MAP2' mapValue contributor 'Anonymous'"
 run_omero "obj map-set '$MAP2' mapValue subject 'Ontop Tutorial'"
 run_omero "obj map-set '$MAP2' mapValue provenance 'Screenshots'"


### PR DESCRIPTION
New single script for replacing separate host-only (insert_data.sh) and CI-only (insert_data_WORKFLOW.sh).

The new script:
- Runs in host mode on Mac an Linux
- Runs in container mode (CI / docker-compose) using flag `MODE=container ./utils/insert_data_unified.sh`
- Disables CLI pagination for non-interactive runs

It also corrects a bug from the original script where MAP2 is created but never linked to anything and instead  link DS2 → MAP1.