### PR TITLE
New script for "Map View" for GEOSPARLQ queries

### DIFF
--- a/deployment_cookiecutter.sh
+++ b/deployment_cookiecutter.sh
@@ -4,19 +4,234 @@ set -Eeuo pipefail
 PYTHON_BIN="${PYTHON_BIN:-python}"
 
 # Temporary working directory for Cookiecutter
-OUT="tmp"                     
+OUT="tmp"
 SETTINGS="${SETTINGS:-omero-ontop-config}"
 BASE_DIR="omero-ontop-mappings"
 
 # 1) Ensure tmp exists  and remove any old content
-if [[ -d "$OUT" ]]; then  
+if [[ -d "$OUT" ]]; then
   rm -rf "$OUT"
 fi
 mkdir -p "$OUT"
 
-echo "🔧 Ontop deployment configuration"
+###############################################################################
+# Optional: update OBDA mapping in an existing deployment
+###############################################################################
 
-# --- Ask user for values 
+echo "🔧 Ontop deployment helper"
+
+while true; do
+  read -r -p "Do you want to update the OBDA mapping of an existing deployment? [no]/yes: " UPDATE_OBDA
+  UPDATE_OBDA=${UPDATE_OBDA:-no}
+  UPDATE_OBDA_LC=$(echo "$UPDATE_OBDA" | tr '[:upper:]' '[:lower:]')
+
+  case "$UPDATE_OBDA_LC" in
+    yes|y)
+      read -r -p "Existing deployment prefix/folder name: " DEPLOY_DIR
+      DEPLOY_DIR="${DEPLOY_DIR%/}"
+
+      if [[ -z "$DEPLOY_DIR" ]]; then
+        echo "ERROR: Deployment folder cannot be empty." >&2
+        exit 1
+      fi
+
+      if [[ ! -d "$DEPLOY_DIR" ]]; then
+        echo "ERROR: Deployment folder '$DEPLOY_DIR' does not exist." >&2
+        exit 1
+      fi
+
+      PREFIX="$(basename "$DEPLOY_DIR")"
+      DEST_OBDA="${DEPLOY_DIR}/${PREFIX}.obda"
+
+      if [[ ! -f "$DEST_OBDA" ]]; then
+        echo "ERROR: Cannot find deployed OBDA file: $DEST_OBDA" >&2
+        exit 1
+      fi
+
+      SITE_URI=$(grep -E "^${PREFIX}:[[:space:]]+" "$DEST_OBDA" | head -n 1 | awk '{print $2}')
+      if [[ -z "${SITE_URI:-}" ]]; then
+        echo " ERROR: Could not extract site_uri from $DEST_OBDA" >&2
+        echo "   Expected a prefix line like:" >&2
+        echo "   ${PREFIX}:   https://example.org/site/" >&2
+        exit 1
+      fi
+
+      SITE=$(echo "$SITE_URI" | sed -e 's/[\/,#]$//')
+
+      PUBLICCOND=$(grep -Eo 'where child[[:space:]]*([=<>!]+)[[:space:]]*[0-9]+' "$DEST_OBDA" \
+        | head -n 1 \
+        | sed -E 's/.*child[[:space:]]*//; s/[[:space:]]//g')
+
+      if [[ -z "${PUBLICCOND:-}" ]]; then
+        echo " ERROR: Could not extract publiccond from $DEST_OBDA" >&2
+        echo "   Expected a SQL fragment like:" >&2
+        echo "   where child=2" >&2
+        echo "   or:" >&2
+        echo "   where child>=0" >&2
+        exit 1
+      fi
+
+      echo ""
+      echo "The update will use these detected values:"
+      echo "   deployment : $DEPLOY_DIR"
+      echo "   prefix     : $PREFIX"
+      echo "   site_uri   : $SITE_URI"
+      echo "   publiccond : $PUBLICCOND"
+      echo ""
+
+      while true; do
+        read -r -p "Continue with OBDA update? [yes]/no: " CONFIRM_UPDATE
+        CONFIRM_UPDATE=${CONFIRM_UPDATE:-yes}
+        CONFIRM_UPDATE_LC=$(echo "$CONFIRM_UPDATE" | tr '[:upper:]' '[:lower:]')
+
+        case "$CONFIRM_UPDATE_LC" in
+          yes|y)
+            break
+            ;;
+          no|n)
+            echo "Update cancelled."
+            exit 0
+            ;;
+          *)
+            echo "Please answer 'yes' or 'no' (or press Enter for 'yes')."
+            ;;
+        esac
+      done
+
+      echo ""
+      echo " Preparing OBDA template from latest repository mapping ..."
+
+      if [[ -f "prepare_obda_template.py" ]]; then
+        if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+          "$PYTHON_BIN" prepare_obda_template.py
+        else
+          echo " ERROR: Python interpreter '$PYTHON_BIN' not found."
+          exit 1
+        fi
+      else
+        echo " ERROR: prepare_obda_template.py not found."
+        exit 1
+      fi
+
+      CC_ARGS=(
+        "templates"
+        -o "$OUT"
+        --no-input
+        deploy_name="$SETTINGS"
+        jdbc_user="dummy"
+        jdbc_password="dummy"
+        db_host="localhost"
+        prefix="$PREFIX"
+        site_uri="$SITE_URI"
+        site="$SITE"
+        publiccond="$PUBLICCOND"
+      )
+
+      echo ""
+      echo "  Regenerating OBDA with Cookiecutter ..."
+      cookiecutter "${CC_ARGS[@]}"
+
+      GEN_DIR=""
+      for d in "$OUT"/*; do
+        if [[ -d "$d" ]]; then
+          GEN_DIR="$d"
+          break
+        fi
+      done
+
+      if [[ -z "$GEN_DIR" ]]; then
+        echo " ERROR: No generated directory found in '$OUT'" >&2
+        exit 1
+      fi
+
+      SRC_OBDA="$GEN_DIR/omero-ontop-mappings.obda"
+
+      if [[ ! -f "$SRC_OBDA" ]]; then
+        echo " ERROR: Generated OBDA file not found at $SRC_OBDA" >&2
+        exit 1
+      fi
+
+      #########################################################################
+      # Update OBDA mapping
+      #########################################################################
+
+      BACKUP_OBDA="${DEST_OBDA}.backup.$(date +%Y%m%d-%H%M%S)"
+      cp -v "$DEST_OBDA" "$BACKUP_OBDA"
+      cp -v "$SRC_OBDA" "$DEST_OBDA"
+
+      echo ""
+      echo " Existing deployment OBDA updated:"
+      echo "   $DEST_OBDA"
+      echo ""
+      echo "Backup created:"
+      echo "   $BACKUP_OBDA"
+
+      #########################################################################
+      # Optionally update ontology (.ttl)
+      #########################################################################
+
+      SRC_TTL="${BASE_DIR}/omero-ontop-mappings.ttl"
+      DEST_TTL="${DEPLOY_DIR}/${PREFIX}.ttl"
+
+      if [[ -f "$SRC_TTL" && -f "$DEST_TTL" ]]; then
+
+        while true; do
+          read -r -p "Also update ontology file (.ttl)? [yes]/no: " UPDATE_TTL
+          UPDATE_TTL=${UPDATE_TTL:-yes}
+          UPDATE_TTL_LC=$(echo "$UPDATE_TTL" | tr '[:upper:]' '[:lower:]')
+
+          case "$UPDATE_TTL_LC" in
+            yes|y)
+              BACKUP_TTL="${DEST_TTL}.backup.$(date +%Y%m%d-%H%M%S)"
+              cp -v "$DEST_TTL" "$BACKUP_TTL"
+              cp -v "$SRC_TTL" "$DEST_TTL"
+
+              echo ""
+              echo " Existing deployment ontology updated:"
+              echo "   $DEST_TTL"
+              echo ""
+              echo "Backup created:"
+              echo "   $BACKUP_TTL"
+              break
+              ;;
+
+            no|n)
+              echo "Skipping ontology update."
+              break
+              ;;
+
+            *)
+              echo "Please answer 'yes' or 'no' (or press Enter for 'yes')."
+              ;;
+          esac
+        done
+
+      else
+        echo ""
+        echo " Ontology update skipped."
+        echo "   Source or destination ontology file not found."
+      fi
+
+      echo ""
+      echo "Next steps:"
+      echo "  cd $DEPLOY_DIR"
+      echo "  ./${PREFIX}-ontop-materialize.sh"
+      echo ""
+      echo "If using QLever, reindex after materializing."
+      exit 0
+      ;;
+    no|n)
+      break
+      ;;
+    *)
+      echo "Please answer 'yes' or 'no' (or press Enter for 'no')."
+      ;;
+  esac
+done
+
+echo " Ontop deployment configuration"
+
+# --- Ask user for values
 echo "Please enter database username (postgres user), password, and its URL, e.g.: localhost or host.example.com"
 read -r -p "Postgres user: " JDBC_USER
 while [[ -z "$JDBC_USER" ]]; do
@@ -41,7 +256,7 @@ PREFIX=${PREFIX:-ex}
 echo "Enter URI: URI of site instance including trailing slash or #, e.g. \"https://institute.of.bioimaging.com/\"."
 read -r -p "site_uri [https://example.org/]: " SITE_URI
 SITE_URI=${SITE_URI:-https://example.org/}
-SITE=$(echo $SITE_URI | sed -e 's/[\/,#]$//')
+SITE=$(echo "$SITE_URI" | sed -e 's/[\/,#]$//')
 echo ""
 echo "Setting public data mapping:"
 echo "  - YES  → Only data of the public user is mapped (enter that user's OMERO ID)."
@@ -146,7 +361,7 @@ else
   echo "⚠️ WARNING: prepare_obda_template.py not found — OBDA template not updated."
 fi
 
-# 2) Build cookiecutter args 
+# 2) Build cookiecutter args
 CC_ARGS=(
   "templates"
   -o "$OUT"
@@ -261,6 +476,9 @@ fi
 # OBDA from Cookiecutter, renamed
 cp -v "$SRC_OBDA" "${PREFIX}/${PREFIX}.obda"
 
+# Deployment values, useful for future update operations
+cp -v "$SRC_ENV" "${PREFIX}/deploy.env"
+
 # Ontop launch script
 if [[ -f "$BASE_DIR/omero-ontop.sh" ]]; then
   sed "s/omero-ontop-mappings/${PREFIX}/g" "$BASE_DIR/omero-ontop.sh" > "${PREFIX}/${PREFIX}-ontop-endpoint.sh"
@@ -276,7 +494,7 @@ db_host_final=$(echo "$jdbc_url" | sed 's#^jdbc:postgresql://##; s/:5432.*$//')
 
 
 echo ""
-echo "✅ Deployment folder created: $PREFIX/"
+echo " Deployment folder created: $PREFIX/"
 
 echo ""
 echo "   Postgres user : $jdbc_user_final"
@@ -341,7 +559,7 @@ EOF
 chmod +x "$MAT_SCRIPT"
 
 echo ""
-echo "🧪 Materialization script created:"
+echo " Materialization script created:"
 echo "   $MAT_SCRIPT"
 echo ""
 ###############################################################################
@@ -357,12 +575,12 @@ if [[ "$CREATE_QLEVER_ENDPOINT" == "yes" ]]; then
   else
     echo "📁 Copying QLever scripts..."
     mkdir -p "$QLEVER_DST"
-    cp -a "$QLEVER_SRC"/. "$QLEVER_DST"/ #portable for Mac and linux. Avoids extra unnecessary subdirectory on ubuntu 
+    cp -a "$QLEVER_SRC"/. "$QLEVER_DST"/ #portable for Mac and linux. Avoids extra unnecessary subdirectory on ubuntu
     chmod +x "$QLEVER_DST/"*.sh 2>/dev/null || true
   fi
 
   echo ""
-  echo "🚀 QLever setup information"
+  echo " QLever setup information"
   echo ""
   echo "To use the QLever SPARQL endpoint, follow these steps:"
   echo ""

--- a/qlever/Qleverfile-ui.yml
+++ b/qlever/Qleverfile-ui.yml
@@ -241,5 +241,5 @@ config:
       } GROUP BY ?qleverui_entity ORDER BY DESC(?qleverui_count)
 
       # ENDIF #
-    mapViewBaseURL: ''
+    mapViewBaseURL: 'http://localhost:9100'
   examples: []

--- a/qlever/petrimaps.sh
+++ b/qlever/petrimaps.sh
@@ -18,7 +18,21 @@ CONTAINER_PORT="9090"
 #
 PETRIMAPS_MODE="${PETRIMAPS_MODE:-linux}"
 
+# Optional Linux helper:
+# If Petrimaps must reach a backend hostname that is resolvable on the host
+# but not inside Docker, set:
+#
+#   PETRIMAPS_HOST_ALIAS=micropop-server-name ./petrimaps.sh restart
+#
+PETRIMAPS_HOST_ALIAS="${PETRIMAPS_HOST_ALIAS:-}"
+
 ACTION="${1:-start}"
+
+docker_host_alias_arg() {
+    if [[ -n "$PETRIMAPS_HOST_ALIAS" ]]; then
+        echo "--add-host=${PETRIMAPS_HOST_ALIAS}:host-gateway"
+    fi
+}
 
 start_container() {
     docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
@@ -29,16 +43,28 @@ start_container() {
 
             docker run -d \
                 --name "$CONTAINER_NAME" \
+                $(docker_host_alias_arg) \
                 -p "${HOST_PORT}:${CONTAINER_PORT}" \
                 --restart unless-stopped \
                 "$IMAGE"
 
-            echo " Petrimaps started"            
+            echo " Petrimaps started"
+            echo "   Mode : linux"
             echo "   URL  : http://localhost:${HOST_PORT}"
+
+            if [[ -n "$PETRIMAPS_HOST_ALIAS" ]]; then
+                echo "   Host alias: ${PETRIMAPS_HOST_ALIAS} -> host-gateway"
+            fi
+
             echo
-            echo "QLever UI configuration:"
-            echo "   baseUrl:        http://localhost:8888"
-            echo "   mapViewBaseURL: http://localhost:${HOST_PORT}"
+            echo "QLever UI YAML configuration:"
+            echo "   Local backend:"
+            echo "     baseUrl:        http://localhost:8888"
+            echo "     mapViewBaseURL: http://localhost:${HOST_PORT}"
+            echo
+            echo "   Proxied backend:"
+            echo "     baseUrl:        http://${PETRIMAPS_HOST_ALIAS:-YOUR_HOSTNAME}/sparql/"
+            echo "     mapViewBaseURL: http://${PETRIMAPS_HOST_ALIAS:-YOUR_HOSTNAME}/petrimaps"
             ;;
 
         mac)
@@ -109,6 +135,7 @@ case "$ACTION" in
         echo "  ./petrimaps.sh"
         echo "  ./petrimaps.sh restart"
         echo "  PETRIMAPS_MODE=mac ./petrimaps.sh"
+        echo "  PETRIMAPS_HOST_ALIAS=micropop-virtuoso ./petrimaps.sh restart"
         exit 1
         ;;
 

--- a/qlever/petrimaps.sh
+++ b/qlever/petrimaps.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="qlever-petrimaps"
+IMAGE="adfreiburg/qlever-petrimaps:latest"
+
+HOST_PORT="${HOST_PORT:-9100}"
+CONTAINER_PORT="9090"
+
+# Deployment mode:
+#
+#   linux (default)
+#       Standard deployment for Linux servers.
+#
+#   mac
+#       Docker Desktop on macOS. Adds the qlever-host alias so
+#       Petrimaps can reach the QLever backend running on the host.
+#
+PETRIMAPS_MODE="${PETRIMAPS_MODE:-linux}"
+
+ACTION="${1:-start}"
+
+start_container() {
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+    case "$PETRIMAPS_MODE" in
+
+        linux)
+
+            docker run -d \
+                --name "$CONTAINER_NAME" \
+                -p "${HOST_PORT}:${CONTAINER_PORT}" \
+                --restart unless-stopped \
+                "$IMAGE"
+
+            echo " Petrimaps started"            
+            echo "   URL  : http://localhost:${HOST_PORT}"
+            echo
+            echo "QLever UI configuration:"
+            echo "   baseUrl:        http://localhost:8888"
+            echo "   mapViewBaseURL: http://localhost:${HOST_PORT}"
+            ;;
+
+        mac)
+
+            docker run -d \
+                --name "$CONTAINER_NAME" \
+                --add-host=qlever-host:host-gateway \
+                -p "${HOST_PORT}:${CONTAINER_PORT}" \
+                --restart unless-stopped \
+                "$IMAGE"
+
+            echo " Petrimaps started"
+            echo "   Mode : macOS"
+            echo "   URL  : http://localhost:${HOST_PORT}"
+            echo
+            echo "Reminder:"
+            echo "   /etc/hosts should contain:"
+            echo "      127.0.0.1 qlever-host"
+            echo
+            echo "QLever UI configuration:"
+            echo "   baseUrl:        http://qlever-host:8888"
+            echo "   mapViewBaseURL: http://localhost:${HOST_PORT}"
+            ;;
+
+        *)
+
+            echo "Unknown PETRIMAPS_MODE: $PETRIMAPS_MODE"
+            echo "Supported modes: linux, mac"
+            exit 1
+
+            ;;
+
+    esac
+}
+
+case "$ACTION" in
+
+    start)
+
+        echo " Starting Petrimaps..."
+        start_container
+        ;;
+
+    stop)
+
+        echo " Stopping Petrimaps..."
+        docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        echo " Petrimaps stopped."
+        ;;
+
+    restart)
+
+        echo " Restarting Petrimaps..."
+        docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+        start_container
+        ;;
+
+    status)
+
+        docker ps --filter "name=$CONTAINER_NAME"
+        ;;
+
+    *)
+
+        echo "Usage: $0 {start|stop|restart|status}"
+        echo
+        echo "Examples:"
+        echo "  ./petrimaps.sh"
+        echo "  ./petrimaps.sh restart"
+        echo "  PETRIMAPS_MODE=mac ./petrimaps.sh"
+        exit 1
+        ;;
+
+esac

--- a/qlever/petrimaps.sh
+++ b/qlever/petrimaps.sh
@@ -7,25 +7,56 @@ IMAGE="adfreiburg/qlever-petrimaps:latest"
 HOST_PORT="${HOST_PORT:-9100}"
 CONTAINER_PORT="9090"
 
-# Deployment mode:
+###############################################################################
+# Petrimaps deployment
 #
-#   linux (default)
-#       Standard deployment for Linux servers.
+# Default QLever UI deployments normally use, when running locally:
 #
-#   mac
-#       Docker Desktop on macOS. Adds the qlever-host alias so
-#       Petrimaps can reach the QLever backend running on the host.
+#   baseUrl: http://localhost:8888
 #
-PETRIMAPS_MODE="${PETRIMAPS_MODE:-linux}"
+# This is fine for qlever-ui itself. However, Petrimaps runs in Docker.
+# If Petrimaps receives:
+#
+#   backend=http://localhost:8888
+#
+# then "localhost" means the Petrimaps container, not the host machine.
+#
+# Therefore, for local Petrimaps testing  (macOS or Linux) use a host alias
+# such as `qlever-host`.
+#
+# Local Petrimaps setup:
+#
+#   1. Add on the host:
+#        127.0.0.1 qlever-host
+#         (echo "127.0.0.1 qlever-host" | sudo tee -a /etc/hosts)
+#
+#   2. Start Petrimaps with:
+#        PETRIMAPS_HOST_ALIAS=qlever-host ./petrimaps.sh restart
+#
+#   3. Change Qleverfile-ui.yml from:
+#        baseUrl: http://localhost:8888
+#
+#      to:
+#        baseUrl: http://qlever-host:8888
+#
+#      The map URL can stay:
+#        mapViewBaseURL: http://localhost:9100
+#
+# Live server setup:
+#
+#   Use the public/proxied backend URL in Qleverfile-ui.yml, for example:
+#
+#        baseUrl:        https://YOUR_SERVER/qlever
+#        mapViewBaseURL: https://YOUR_SERVER/petrimaps
+#
+#   Then proxy /petrimaps/ to localhost:9100.
+#
+#   If the backend hostname is not reachable from inside Docker, start with:
+#
+#        PETRIMAPS_HOST_ALIAS=YOUR_HOSTNAME ./petrimaps.sh restart
+###############################################################################
 
-# Optional Linux helper:
-# If Petrimaps must reach a backend hostname that is resolvable on the host
-# but not inside Docker, set:
-#
-#   PETRIMAPS_HOST_ALIAS=micropop-server-name ./petrimaps.sh restart
-#
 PETRIMAPS_HOST_ALIAS="${PETRIMAPS_HOST_ALIAS:-}"
-
 ACTION="${1:-start}"
 
 docker_host_alias_arg() {
@@ -37,106 +68,71 @@ docker_host_alias_arg() {
 start_container() {
     docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
 
-    case "$PETRIMAPS_MODE" in
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        $(docker_host_alias_arg) \
+        -p "${HOST_PORT}:${CONTAINER_PORT}" \
+        --restart unless-stopped \
+        "$IMAGE"
 
-        linux)
+    echo " Petrimaps started"
+    echo "   URL: http://localhost:${HOST_PORT}"
 
-            docker run -d \
-                --name "$CONTAINER_NAME" \
-                $(docker_host_alias_arg) \
-                -p "${HOST_PORT}:${CONTAINER_PORT}" \
-                --restart unless-stopped \
-                "$IMAGE"
+    if [[ -n "$PETRIMAPS_HOST_ALIAS" ]]; then
+        echo "   Host alias: ${PETRIMAPS_HOST_ALIAS} -> host-gateway"
+    fi
 
-            echo " Petrimaps started"
-            echo "   Mode : linux"
-            echo "   URL  : http://localhost:${HOST_PORT}"
-
-            if [[ -n "$PETRIMAPS_HOST_ALIAS" ]]; then
-                echo "   Host alias: ${PETRIMAPS_HOST_ALIAS} -> host-gateway"
-            fi
-
-            echo
-            echo "QLever UI YAML configuration:"
-            echo "   Local backend:"
-            echo "     baseUrl:        http://localhost:8888"
-            echo "     mapViewBaseURL: http://localhost:${HOST_PORT}"
-            echo
-            echo "   Proxied backend:"
-            echo "     baseUrl:        http://${PETRIMAPS_HOST_ALIAS:-YOUR_HOSTNAME}/sparql/"
-            echo "     mapViewBaseURL: http://${PETRIMAPS_HOST_ALIAS:-YOUR_HOSTNAME}/petrimaps"
-            ;;
-
-        mac)
-
-            docker run -d \
-                --name "$CONTAINER_NAME" \
-                --add-host=qlever-host:host-gateway \
-                -p "${HOST_PORT}:${CONTAINER_PORT}" \
-                --restart unless-stopped \
-                "$IMAGE"
-
-            echo " Petrimaps started"
-            echo "   Mode : macOS"
-            echo "   URL  : http://localhost:${HOST_PORT}"
-            echo
-            echo "Reminder:"
-            echo "   /etc/hosts should contain:"
-            echo "      127.0.0.1 qlever-host"
-            echo
-            echo "QLever UI configuration:"
-            echo "   baseUrl:        http://qlever-host:8888"
-            echo "   mapViewBaseURL: http://localhost:${HOST_PORT}"
-            ;;
-
-        *)
-
-            echo "Unknown PETRIMAPS_MODE: $PETRIMAPS_MODE"
-            echo "Supported modes: linux, mac"
-            exit 1
-
-            ;;
-
-    esac
+    echo
+    echo "Note:"
+    echo "   If Qleverfile-ui.yml uses baseUrl: http://localhost:8888,"
+    echo "   qlever-ui will work, but Petrimaps may fail because localhost"
+    echo "   inside the Petrimaps container is not the host machine."
+    echo
+    echo " Qleverfile-ui.yml configuration examples:"
+    echo
+    echo "   Default qlever-ui only, no Petrimaps:"
+    echo "     baseUrl:        http://localhost:8888"
+    echo
+    echo "   Local development with Petrimaps:"
+    echo "     baseUrl:        http://qlever-host:8888"
+    echo "     mapViewBaseURL: http://localhost:${HOST_PORT}"
+    echo
+    echo "   Live server with public/proxied backend:"
+    echo "     baseUrl:        http(s)://YOUR_SERVER/YOUR_BACKEND_ENDPOINT"
+    echo "     mapViewBaseURL: http(s)://YOUR_SERVER/petrimaps"
+    echo
 }
 
 case "$ACTION" in
-
     start)
-
         echo " Starting Petrimaps..."
         start_container
         ;;
 
     stop)
-
         echo " Stopping Petrimaps..."
         docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
         echo " Petrimaps stopped."
         ;;
 
     restart)
-
         echo " Restarting Petrimaps..."
         docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
         start_container
         ;;
 
     status)
-
         docker ps --filter "name=$CONTAINER_NAME"
         ;;
 
     *)
-
         echo "Usage: $0 {start|stop|restart|status}"
         echo
         echo "Examples:"
         echo "  ./petrimaps.sh"
         echo "  ./petrimaps.sh restart"
-        echo "  PETRIMAPS_MODE=mac ./petrimaps.sh"
+        echo "  PETRIMAPS_HOST_ALIAS=qlever-host ./petrimaps.sh restart"
         echo "  PETRIMAPS_HOST_ALIAS=micropop-virtuoso ./petrimaps.sh restart"
         exit 1
         ;;
-
 esac

--- a/qlever/reindex_ome_data.sh
+++ b/qlever/reindex_ome_data.sh
@@ -214,6 +214,7 @@ docker run --rm \
       -f '${DATA_FILE_IN_C}' \
       -g '${GRAPH_URI}' \
       -F ttl -p false \
+      --parser-buffer-size 500M \
       --stxxl-memory ${STXXL_MEMORY}
   " | tee "$LOG_FILE"
 


### PR DESCRIPTION
`petrimaps.sh` creates a docker container that runs petrimaps (https://github.com/ad-freiburg/qlever-petrimaps) which enables the maps in qlever-ui.
In order to work,  `mapViewBaseURL` needs to be specified in  Qleverfile-ui.yml. The default value that works when working with locahost is:
        mapViewBaseURL: http://localhost:9100

However, when running locally no web server, such as nginx, is used to redirect the requests. In that case, we need to create an alias so qlever and petrimaps can communicate, for example `qlever-host`.  Then we need to change `baseUrl` to:
 baseUrl: http://qlever-host:8888
 
 and then run the script like this: `PETRIMAPS_HOST_ALIAS=qlever-host ./petrimaps.sh start`

When running in host with resolvable hostname, and with a web server setup to proxy the correct urls, such as in the Muester server, where we have:
baseUrl: http://idr-sparql.uni-muenster.de/muenster-omero-sparql 
mapViewBaseURL: http://idr-sparql.uni-muenster.de/petrimaps

The script works simply like this: 

   `./petrimaps.sh`
   `./petrimaps stop`

With that the map view is enable when running a GEOSPARQ query such as:

PREFIX geo: <http://www.opengis.net/ont/geosparql#>
PREFIX dc:  <http://purl.org/dc/elements/1.1/>

SELECT ?image_ID ?wkt
WHERE {
  ?image
      dc:identifier ?image_ID ;
      geo:hasGeometry/geo:asWKT ?wkt .
}
LIMIT 10